### PR TITLE
Remove separator argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Changes
 development (master)
 --------------------
 
+- Remove configurable key separator, hardcode the default.
 - Rename enumeration values (like `Locality.USER`) to be upper case.
 
 0.9 (2021-02-01)

--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -51,20 +51,19 @@ def merge(left: typing.MutableMapping[str, typing.Any],
 
 
 def split_keys(mapping: typing.Mapping[str, typing.Any],
-               separator: str = '.',
                colliding: typing.Optional[typing.Container] = None) -> typing.Mapping[str, typing.Any]:
     """
-    Recursively walks *mapping* to split keys that contain the separator into
-    nested mappings.
+    Recursively walks *mapping* to split keys that contain a dot into nested
+    mappings.
 
     .. note::
 
         Keys not of type `str` are not supported and will raise errors.
 
     :param mapping: the mapping to process
-    :param separator: the character (sequence) to use as the separator between
-        keys
-    :return: a mapping where keys containing *separator* are split into nested
+    :param colliding: a container of keys (names) that should be triggering a
+        warning that they collide with other functionality
+    :return: a mapping where keys containing a dot are split into nested
         mappings
     """
     result: typing.MutableMapping[str, typing.Any] = {}
@@ -72,18 +71,18 @@ def split_keys(mapping: typing.Mapping[str, typing.Any],
     for key, value in mapping.items():
         if isinstance(value, Mapping):
             # recursively split key(s) in value
-            value = split_keys(value, separator)
+            value = split_keys(value)
 
         # reject non-str keys, avoid complicating access patterns
         if not isinstance(key, str):
             raise ValueError(f'non-str type keys ({key}, {key.__class__.__module__}.{key.__class__.__name__}) '
                              'not supported')
 
-        if separator in key:
-            # update key to be the first part before the separator
-            key, rest = key.split(separator, 1)
+        if '.' in key:
+            # update key to be the first part before the dot separator
+            key, rest = key.split('.', 1)
             # use rest as the new key of value, recursively split that and update value
-            value = split_keys({rest: value}, separator)
+            value = split_keys({rest: value})
 
         if colliding and key in colliding:
             # warn about configured keys colliding with Configuration members

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,8 +1,8 @@
-from confidence import Configuration
+from confidence import Configuration, NotConfigured
 
 
 def test_constructor_defaults():
     subject = Configuration()
-    assert subject._separator == '.'
+    assert subject._missing == NotConfigured
     assert len(subject) == len(subject._source) == 0
     assert list(subject) == []

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -49,16 +49,15 @@ def test_not_configured():
 
 def test_collisions():
     with patch('confidence.utils.warnings') as warnings:
-        subject = Configuration({'key': 'value', 'keys': [1, 2], '_separator': '_'})
+        subject = Configuration({'key': 'value', 'keys': [1, 2], '_missing': 'error'})
 
-    for collision in ('keys', '_separator'):
+    for collision in ('keys', '_missing'):
         warnings.warn.assert_any_call(f'key {collision} collides with a named member, use get() method to '
                                       f'retrieve the value for {collision}',
                                       UserWarning)
 
     assert subject.key == 'value'
     assert callable(subject.keys)
-    assert subject._separator == '.'
 
 
 def test_dir():


### PR DESCRIPTION
Rarely useful or used, the default was basically the only thing that made sense anyways.

Fixes #68.