### PR TITLE
Silence logging by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,13 +4,13 @@ Changes
 development (master)
 --------------------
 
-- Use named loggers, default `confidence.*` loggers to silence
+- Use named loggers, default `confidence.*` library loggers to silence as [described in the docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).
 
 0.11 (2021-11-25)
 -----------------
 
-- Parse values of environment variables as YAML values (e.g. `NAME_KEY=yes` will result in `key` being `True`)
-- Add INFO-level logging of files and environment variables being used to load configuration
+- Parse values of environment variables as YAML values (e.g. `NAME_KEY=yes` will result in `key` being `True`).
+- Add INFO-level logging of files and environment variables being used to load configuration.
 
 0.10 (2021-08-04)
 -----------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Changes
 development (master)
 --------------------
 
+- Use named loggers, default `confidence.*` loggers to silence
+
 0.11 (2021-11-25)
 -----------------
 

--- a/check-requirements.txt
+++ b/check-requirements.txt
@@ -43,11 +43,11 @@ flake8-quotes==3.3.1
     # via -r check-requirements.in
 flake8-rst-docstrings==0.2.5
     # via -r check-requirements.in
-flake8-simplify==0.15.1
+flake8-simplify==0.18.0
     # via -r check-requirements.in
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.26
+gitpython==3.1.27
     # via bandit
 importlib-metadata==4.2.0
     # via
@@ -81,13 +81,13 @@ smmap==5.0.0
     # via gitdb
 stevedore==3.5.0
     # via bandit
-tomli==2.0.0
+tomli==2.0.1
     # via mypy
 typed-ast==1.5.2
     # via mypy
 types-pyyaml==6.0.4
     # via -r check-requirements.in
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   gitpython
     #   importlib-metadata

--- a/check-requirements.txt
+++ b/check-requirements.txt
@@ -2,9 +2,9 @@ astor==0.8.1
     # via flake8-simplify
 astpretty==2.1.0
     # via flake8-expression-complexity
-attrs==21.2.0
+attrs==21.4.0
     # via flake8-bugbear
-bandit==1.7.1
+bandit==1.7.2
     # via -r check-requirements.in
 darglint==1.8.1
     # via -r check-requirements.in
@@ -27,11 +27,11 @@ flake8-annotations-complexity==0.0.6
     # via -r check-requirements.in
 flake8-broken-line==0.4.0
     # via -r check-requirements.in
-flake8-bugbear==21.11.29
+flake8-bugbear==22.1.11
     # via -r check-requirements.in
 flake8-commas==2.1.0
     # via -r check-requirements.in
-flake8-comprehensions==3.7.0
+flake8-comprehensions==3.8.0
     # via -r check-requirements.in
 flake8-expression-complexity==0.0.9
     # via -r check-requirements.in
@@ -41,13 +41,13 @@ flake8-polyfill==1.0.2
     # via pep8-naming
 flake8-quotes==3.3.1
     # via -r check-requirements.in
-flake8-rst-docstrings==0.2.3
+flake8-rst-docstrings==0.2.5
     # via -r check-requirements.in
-flake8-simplify==0.14.2
+flake8-simplify==0.15.1
     # via -r check-requirements.in
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.18
+gitpython==3.1.26
     # via bandit
 importlib-metadata==4.2.0
     # via
@@ -57,11 +57,11 @@ importlib-metadata==4.2.0
     #   stevedore
 mccabe==0.6.1
     # via flake8
-mypy==0.910
+mypy==0.931
     # via -r check-requirements.in
 mypy-extensions==0.4.3
     # via mypy
-pbr==5.8.0
+pbr==5.8.1
     # via stevedore
 pep8-naming==0.12.1
     # via -r check-requirements.in
@@ -71,7 +71,7 @@ pycodestyle==2.8.0
     #   flake8-import-order
 pyflakes==2.4.0
     # via flake8
-pygments==2.10.0
+pygments==2.11.2
     # via flake8-rst-docstrings
 pyyaml==6.0
     # via bandit
@@ -81,18 +81,18 @@ smmap==5.0.0
     # via gitdb
 stevedore==3.5.0
     # via bandit
-toml==0.10.2
+tomli==2.0.0
     # via mypy
-typed-ast==1.4.3
+typed-ast==1.5.2
     # via mypy
-types-pyyaml==6.0.1
+types-pyyaml==6.0.4
     # via -r check-requirements.in
 typing-extensions==4.0.1
     # via
     #   gitpython
     #   importlib-metadata
     #   mypy
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from confidence.exceptions import ConfigurationError, ConfiguredReferenceError, MergeConflictError, NotConfiguredError
 from confidence.io import DEFAULT_LOAD_ORDER, dump, dumpf, dumps, load, load_name, loaders, loadf, loads, Locality
 from confidence.models import Configuration, Missing, NotConfigured
@@ -8,3 +10,7 @@ __all__ = (
     'DEFAULT_LOAD_ORDER', 'dump', 'dumpf', 'dumps', 'load', 'load_name', 'loaders', 'loadf', 'loads', 'Locality',
     'Configuration', 'Missing', 'NotConfigured',
 )
+
+
+# default confidence' loggers to silence, can be overridden from logging later if needed
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -1,9 +1,12 @@
 from collections.abc import Mapping
 from enum import IntEnum
+import logging
 import typing
-import warnings
 
 from confidence.exceptions import MergeConflictError
+
+
+LOG = logging.getLogger(__name__)
 
 
 class Conflict(IntEnum):
@@ -89,8 +92,7 @@ def split_keys(mapping: typing.Mapping[str, typing.Any],
 
         if colliding and key in colliding:
             # warn about configured keys colliding with Configuration members
-            warnings.warn(f'key {key} collides with a named member, use get() method to retrieve the value for {key}',
-                          UserWarning)
+            LOG.warning('key "%s" collides with a named member, use the get() method to retrieve its value', key)
 
         # merge the result so far with the (possibly updated / fixed / split) current key and value
         merge(result, {key: value})

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -5,7 +5,9 @@ How to use confidence
 - loading by name
 - creating `.Configuration` objects manually
 
-Caveats
+Logging
 -------
 
-- envvars are always strings
+``confidence`` uses the logging module in the standard library for its logging needs, but the loggers are silenced by default.
+See logging's documentation to configure the logging mechanism for your needs.
+Loggers are named after the module they're defined in, e.g. ``confidence.io``.

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,12 +38,12 @@ def test(session):
 
 
 @nox.session(python=oldest_python)
-def update_deps(session):
+def update(session):
     session.install('pip-tools')
 
-    session.run('pip-compile', '--upgrade', '--no-header', '--output-file', 'requirements.txt', 'setup.py')
-    session.run('pip-compile', '--upgrade', '--no-header', '--output-file', 'check-requirements.txt', 'check-requirements.in')
-    session.run('pip-compile', '--upgrade', '--no-header', '--output-file', 'test-requirements.txt', 'test-requirements.in')
+    session.run('pip-compile', '--upgrade', '--no-header', '--no-emit-index-url', '--output-file', 'requirements.txt', 'setup.py')
+    session.run('pip-compile', '--upgrade', '--no-header', '--no-emit-index-url', '--output-file', 'check-requirements.txt', 'check-requirements.in')
+    session.run('pip-compile', '--upgrade', '--no-header', '--no-emit-index-url', '--output-file', 'test-requirements.txt', 'test-requirements.in')
 
 
 @nox.session(python=oldest_python)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
 attrs==21.4.0
     # via pytest
-coverage==6.3.1
+coverage==6.3.2
     # via -r test-requirements.in
-importlib-metadata==4.10.1
+importlib-metadata==4.11.1
     # via
     #   pluggy
     #   pytest
@@ -16,11 +16,11 @@ py==1.11.0
     # via pytest
 pyparsing==3.0.7
     # via packaging
-pytest==7.0.0
+pytest==7.0.1
     # via -r test-requirements.in
-tomli==2.0.0
+tomli==2.0.1
     # via pytest
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via importlib-metadata
 zipp==3.7.0
     # via importlib-metadata

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
-coverage==6.2
+coverage==6.3.1
     # via -r test-requirements.in
-importlib-metadata==4.8.2
+importlib-metadata==4.10.1
     # via
     #   pluggy
     #   pytest
@@ -14,13 +14,13 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pytest==6.2.5
+pytest==7.0.0
     # via -r test-requirements.in
-toml==0.10.2
+tomli==2.0.0
     # via pytest
 typing-extensions==4.0.1
     # via importlib-metadata
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-metadata

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -48,13 +48,12 @@ def test_not_configured():
 
 
 def test_collisions():
-    with patch('confidence.utils.warnings') as warnings:
+    with patch('confidence.utils.LOG') as logger:
         subject = Configuration({'key': 'value', 'keys': [1, 2], '_missing': 'error'})
 
     for collision in ('keys', '_missing'):
-        warnings.warn.assert_any_call(f'key {collision} collides with a named member, use get() method to '
-                                      f'retrieve the value for {collision}',
-                                      UserWarning)
+        logger.warning.assert_any_call('key "%s" collides with a named member, use the get() method to '
+                                       'retrieve its value', collision)
 
     assert subject.key == 'value'
     assert callable(subject.keys)


### PR DESCRIPTION
As applied by many libs and recommended by some [source](https://realpython.com/python-logging-source-code/#library-vs-application-logging-what-is-nullhandler)s, default all of the `confidence.*` logging handlers to be silent; logging should be an opt-in.

Small local test makes the logging show up when using `logging.basicConfig(level=logging.DEBUG)`, so not sure exactly how silent this makes the lib (doing this before importing the io module didn't change that). 