### PR TITLE
Resolve references in sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ development (master)
 --------------------
 
 - Use named loggers, default `confidence.*` library loggers to silence as [described in the docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).
+- Resolve references in sequences.
 
 0.11 (2021-11-25)
 -----------------

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -61,10 +61,10 @@ class Configuration(Mapping):
                 # merge values from source into self._source, overwriting any corresponding keys
                 merge(self._source, split_keys(source, colliding=_COLLIDING_KEYS), conflict=Conflict.OVERWRITE)
 
-    def _wrap(self, value: typing.MutableMapping[str, typing.Any]) -> 'Configuration':
+    def _wrap(self, value: typing.Mapping[str, typing.Any]) -> 'Configuration':
         # create an instance of our current type, copying 'configured' properties / policies
         namespace = type(self)(missing=self._missing)
-        namespace._source = value
+        namespace._source = value  # type: ignore  # mutability isn't needed after init
         # carry the root object from namespace to namespace, references are always resolved from root
         namespace._root = self._root
         return namespace

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -113,6 +113,7 @@ class Configuration(Mapping):
     def get(self,
             path: str,
             default: typing.Any = NoDefault,
+            *,
             as_type: typing.Optional[typing.Callable] = None,
             resolve_references: bool = True) -> typing.Any:
         """

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-nox.options.sessions = ('check', 'tests')
+nox.options.sessions = ('check', 'test')
 
 
 all_supported_pythons = ('3.7', '3.8', '3.9', '3.10', 'pypy3')

--- a/tests/files/complicated.yaml
+++ b/tests/files/complicated.yaml
@@ -22,3 +22,8 @@ different.types:
         - sequence_with: a mapping inside it, with ${a.complicated.2019.a} reference (mind = blown)
   - maybe: another mapping, for fun
   - [1, 2, 3, 4]
+
+different.sequence:
+  - simple value
+  - ${a.complicated.example}
+  - value with ${a.complicatedion.2019.a} reference in it

--- a/tests/files/complicated.yaml
+++ b/tests/files/complicated.yaml
@@ -26,4 +26,5 @@ different.types:
 different.sequence:
   - simple value
   - ${a.complicated.example}
-  - value with ${a.complicatedion.2019.a} reference in it
+  - value with ${a.complicated.2019.a} reference in it
+  - ${a.complicated}

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -35,6 +35,15 @@ def test_nested_sequence_mapping(complicated_config):
     assert complicated_config.different.types[3].containing.surprise[0] == 'another'
 
 
+def test_sequence_reference(complicated_config):
+    seq = complicated_config.different.sequence
+
+    assert isinstance(seq, Sequence)
+    assert seq[0] == 'simple value'
+    assert seq[1] == 'example'
+    assert seq[2] == 'value with a reference in it'
+
+
 def test_deep_reference(complicated_config):
     ns = complicated_config.different.types[3].containing.surprise[1]
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -42,6 +42,7 @@ def test_sequence_reference(complicated_config):
     assert seq[0] == 'simple value'
     assert seq[1] == 'example'
     assert seq[2] == 'value with a reference in it'
+    assert seq[3].example == 'example'
 
 
 def test_deep_reference(complicated_config):


### PR DESCRIPTION
Would simply return strings with references in them, surprisingly. See tests and `complicated.yaml` for intended change.