### PR TITLE
Add system-wide named directory + named file paths to default load order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Changes
 development (master)
 --------------------
 
+- Add system-wide `.../name/name.yaml` paths to the default load order, aiding in the use configuration *directories* (e.g. in containerized setups). 
+
 0.13 (2023-01-02)
 -----------------
 

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -159,7 +159,9 @@ _LOADERS: typing.Mapping[Locality, typing.Iterable[Loadable]] = {
     Locality.SYSTEM: (
         # system-wide locations
         read_xdg_config_dirs,
+        '/etc/{name}/{name}.{extension}',
         '/etc/{name}.{extension}',
+        '/Library/Preferences/{name}/{name}.{extension}',
         '/Library/Preferences/{name}.{extension}',
         partial(read_envvar_dir, 'PROGRAMDATA'),
     ),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -201,8 +201,12 @@ def test_load_name_order(broken_open):
     mocked_open.assert_has_calls([
         call('/etc/xdg/foo.yaml', 'r'),
         call('/etc/xdg/bar.yaml', 'r'),
+        call('/etc/foo/foo.yaml', 'r'),
+        call('/etc/bar/bar.yaml', 'r'),
         call('/etc/foo.yaml', 'r'),
         call('/etc/bar.yaml', 'r'),
+        call('/Library/Preferences/foo/foo.yaml', 'r'),
+        call('/Library/Preferences/bar/bar.yaml', 'r'),
         call('/Library/Preferences/foo.yaml', 'r'),
         call('/Library/Preferences/bar.yaml', 'r'),
         call('/home/user/.config/foo.yaml', 'r'),


### PR DESCRIPTION
Should aid in containerized setups, where volume-mounting a directory is a widely used implementation of shipping configuration to a container image. This also mimics paths used by many packages (e.g. elasticsearch, cassandra, ...).

This will however now aid in a setup where both `/etc/my-app/database.yaml` and `/etc/my-app/my-app.yaml` are volume mounted into a container, the former being ignored by confidence unless the application adds something `/etc/my-app/{name}.yaml` to the load order (come to think of it, adding that would cause `/etc/my-app/my-app.yaml` to be loaded twice :see_no_evil:).

Reviewers, please also checkout #94, we might be able to come up with a way to steal / reuse more well-known behaviours (like adding `/etc/{name}/{name}.{extension}.d/*`) in ways that would aid this use case.