### PR TITLE
Expose unwrap function as public API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Changes
 development (master)
 --------------------
 
+- Add `unwrap` function to the public API, unwrapping a `Configuration` object into a plain `dict` (note that references are not resolved and will remain references in the result).
+
 0.14 (2023-02-28)
 -----------------
 

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -2,13 +2,13 @@ import logging
 
 from confidence.exceptions import ConfigurationError, ConfiguredReferenceError, MergeConflictError, NotConfiguredError
 from confidence.io import DEFAULT_LOAD_ORDER, dump, dumpf, dumps, load, load_name, loaders, loadf, loads, Locality
-from confidence.models import Configuration, Missing, NotConfigured
+from confidence.models import Configuration, Missing, NotConfigured, unwrap
 
 
 __all__ = (
     'ConfigurationError', 'ConfiguredReferenceError', 'MergeConflictError', 'NotConfiguredError',
     'DEFAULT_LOAD_ORDER', 'dump', 'dumpf', 'dumps', 'load', 'load_name', 'loaders', 'loadf', 'loads', 'Locality',
-    'Configuration', 'Missing', 'NotConfigured',
+    'Configuration', 'Missing', 'NotConfigured', 'unwrap',
 )
 
 

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -8,7 +8,7 @@ import typing
 
 import yaml
 
-from confidence.models import _unwrap, Configuration, Missing, NoDefault, NotConfigured
+from confidence.models import Configuration, Missing, NoDefault, NotConfigured, unwrap
 
 
 LOG = logging.getLogger(__name__)
@@ -329,7 +329,7 @@ def dump(value: typing.Any, fp: typing.IO, encoding: str = 'utf-8') -> None:
     """
     # recursively unwrap the value to help yaml understand what we're trying to dump
     # use block style output for nested collections (flow style dumps nested dicts inline)
-    yaml.safe_dump(_unwrap(value), stream=fp, encoding=encoding, default_flow_style=False)
+    yaml.safe_dump(unwrap(value), stream=fp, encoding=encoding, default_flow_style=False)
 
 
 def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], encoding: str = 'utf-8') -> None:
@@ -353,7 +353,7 @@ def dumps(value: typing.Any) -> str:
     """
     # recursively unwrap the value to help yaml understand what we're trying to dump
     # use block style output for nested collections (flow style dumps nested dicts inline)
-    encoded = yaml.safe_dump(_unwrap(value), default_flow_style=False)
+    encoded = yaml.safe_dump(unwrap(value), default_flow_style=False)
     # omit explicit document end (...) included with simple values
     # (to be replaced with encoded.removesuffix('\n...\n') when python requirement hits 3.9+)
     return encoded[:-4] if encoded.endswith('...\n') else encoded

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -22,7 +22,7 @@ NoDefault = type('NoDefault', (object,), {
 })()  # create instance of that new type to assign to NoDefault
 
 
-def _unwrap(source: typing.Any) -> typing.Any:
+def unwrap(source: typing.Any) -> typing.Any:
     """
     Recursively walks *source* to turn occurrences of wrapper types into their
     simple counterparts.
@@ -36,14 +36,18 @@ def _unwrap(source: typing.Any) -> typing.Any:
 
     if isinstance(source, ConfigurationSequence):
         # sequence will resolve references, unwrap values in its source
-        return [_unwrap(value) for value in source._source]
+        return [unwrap(value) for value in source._source]
 
     if isinstance(source, Mapping):
         # mapping type can no longer be a Configuration, use .items() to unwrap values
-        return {key: _unwrap(value) for key, value in source.items()}
+        return {key: unwrap(value) for key, value in source.items()}
 
     # nothing needed, use value as-is
     return source
+
+
+# retain old private name, alias to be removed soon™
+_unwrap = unwrap
 
 
 class Configuration(Mapping):
@@ -80,7 +84,7 @@ class Configuration(Mapping):
             if source:
                 # merge values from source into self._source, overwriting any corresponding keys
                 # unwrap the source to make sure we're dealing with simple types
-                merge(self._source, split_keys(_unwrap(source), colliding=_COLLIDING_KEYS), conflict=Conflict.OVERWRITE)
+                merge(self._source, split_keys(unwrap(source), colliding=_COLLIDING_KEYS), conflict=Conflict.OVERWRITE)
 
     def _wrap(self, value: typing.Mapping[str, typing.Any]) -> 'Configuration':
         # create an instance of our current type, copying 'configured' properties / policies

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -46,10 +46,6 @@ def unwrap(source: typing.Any) -> typing.Any:
     return source
 
 
-# retain old private name, alias to be removed soon™
-_unwrap = unwrap
-
-
 class Configuration(Mapping):
     """
     A collection of configured values, retrievable as either `dict`-like items


### PR DESCRIPTION
Fixes #101.

#97 is still open, that might make more sense now `unwrap` is being made part of the public API. The readability thing is still up for debate though, and maybe not part of this PR.