### PR TITLE
Improve sequence repr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ development (master)
 --------------------
 
 - Add `unwrap` function to the public API, unwrapping a `Configuration` object into a plain `dict` (note that references are not resolved and will remain references in the result).
+- Change string-representations (result of `repr()`) of `Configuration` and `ConfigurationSequence` to be more like builtin types.
 
 0.14 (2023-02-28)
 -----------------

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -233,9 +233,8 @@ class Configuration(Mapping):
         return sorted(set(chain(super().__dir__(), self.keys())))
 
     def __repr__(self) -> str:
-        # even though keys should always be str, no need to crash on repr() in edge cases
-        keys = ', '.join(str(key) for key in self.keys())
-        return f'{self.__class__.__module__}.{self.__class__.__name__}(keys={{{keys}}})'
+        keys = ', '.join(_repr_value(key) for key in self.keys())
+        return f'{self.__class__.__module__}.{self.__class__.__name__}(keys=[{keys}])'
 
     def __getstate__(self) -> typing.Dict[str, typing.Any]:
         state = self.__dict__.copy()

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -235,7 +235,7 @@ class Configuration(Mapping):
     def __repr__(self) -> str:
         # even though keys should always be str, no need to crash on repr() in edge cases
         keys = ', '.join(str(key) for key in self.keys())
-        return f'<{self.__class__.__module__}.{self.__class__.__name__} keys={{{keys}}}>'
+        return f'{self.__class__.__module__}.{self.__class__.__name__}(keys={{{keys}}})'
 
     def __getstate__(self) -> typing.Dict[str, typing.Any]:
         state = self.__dict__.copy()
@@ -340,7 +340,7 @@ class ConfigurationSequence(Sequence):
     def __repr__(self) -> str:
         # use _source to avoid wrapping and resolving values
         values = ', '.join(_repr_value(value) for value in self._source)
-        return f'<{self.__class__.__module__}.{self.__class__.__name__} [{values}]>'
+        return f'{self.__class__.__module__}.{self.__class__.__name__}([{values}])'
 
 
 def _repr_value(value: typing.Any) -> str:

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -338,5 +338,18 @@ class ConfigurationSequence(Sequence):
         return type(other)(list(other) + list(self))  # type: ignore
 
     def __repr__(self) -> str:
-        values = ', '.join(repr(value) for value in self)
+        # use _source to avoid wrapping and resolving values
+        values = ', '.join(_repr_value(value) for value in self._source)
         return f'<{self.__class__.__module__}.{self.__class__.__name__} [{values}]>'
+
+
+def _repr_value(value: typing.Any) -> str:
+    if isinstance(value, Mapping):
+        # represent a mapping as just its keys
+        keys = ', '.join(str(key) for key in value.keys())
+        return f'keys={{{keys}}}'
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return '[...]'
+
+    # fall back to builtin repr
+    return repr(value)

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -345,11 +345,10 @@ class ConfigurationSequence(Sequence):
 
 def _repr_value(value: typing.Any) -> str:
     if isinstance(value, Mapping):
-        # represent a mapping as just its keys
-        keys = ', '.join(str(key) for key in value.keys())
-        return f'keys={{{keys}}}'
+        keys = ', '.join(_repr_value(key) for key in value.keys())
+        return f'mapping(keys=[{keys}])'
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return '[...]'
+        return 'sequence([...])'
 
     # fall back to builtin repr
     return repr(value)

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -343,6 +343,12 @@ class ConfigurationSequence(Sequence):
 
 
 def _repr_value(value: typing.Any) -> str:
+    """
+    Create a `repr` for value, customizing mapping and sequence types.
+
+    :param value: an object to represent
+    :return: a string-representation of *value*
+    """
     if isinstance(value, Mapping):
         keys = ', '.join(_repr_value(key) for key in value.keys())
         return f'mapping(keys=[{keys}])'

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -10,6 +10,7 @@ def test_empty():
     def run_test(subject):
         assert subject.key is NotConfigured
         assert subject.deeper.key is NotConfigured
+        assert 'keys={}' in repr(subject)
 
     run_test(Configuration())
     run_test(Configuration({}))
@@ -31,6 +32,10 @@ def test_value_types():
     assert isinstance(subject.a_boolean, bool)
     assert isinstance(subject.a_list, Sequence)
     assert isinstance(subject.we_must, Mapping)
+
+    assert 'a_string' in repr(subject)
+    assert 'just' not in repr(subject)
+    assert 'go_deeper' not in repr(subject)
 
 
 def test_not_configured():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -10,7 +10,7 @@ def test_empty():
     def run_test(subject):
         assert subject.key is NotConfigured
         assert subject.deeper.key is NotConfigured
-        assert 'keys={}' in repr(subject)
+        assert '(keys=[])' in repr(subject)
 
     run_test(Configuration())
     run_test(Configuration({}))

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -22,6 +22,8 @@ def test_configured_sequence(complicated_config):
     assert complicated_config.different.types[5][0] == 1
     assert complicated_config.different.types[5][3] == 4
 
+    assert "'a string', True, 42.0" in repr(complicated_config.different.types)
+
 
 def test_sequence_mapping(complicated_config):
     assert isinstance(complicated_config.different.types[3], Mapping)
@@ -71,6 +73,12 @@ def test_addition(complicated_config):
     assert len(sequence + (1, 2, 3)) == 9
     assert len((1, 2, 3) + sequence) == 9
     assert isinstance((1, 2, 3) + sequence, tuple)
+
+    for value in ('str', 42):
+        with pytest.raises(TypeError):
+            assert sequence + value
+        with pytest.raises(TypeError):
+            assert value + sequence
 
 
 def test_addition_wrap(complicated_config):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -3,6 +3,7 @@ from os import path
 
 import pytest
 
+import confidence
 from confidence import loadf
 
 
@@ -90,3 +91,22 @@ def test_addition_wrap(complicated_config):
     mapping = {'a': {'mapping': 42}}
     sequence = sequence + [1, 2, mapping, 4]
     assert sequence[-2].a.mapping == 42
+
+
+def test_repr(complicated_config):
+    sequence = complicated_config.different.sequence
+
+    assert 'keys={' not in repr(sequence)
+    assert '[...]' not in repr(sequence)
+    assert '${' in repr(sequence)
+
+    assert 'keys={' in repr(sequence + [{'namespaces': 'honking great idea'}])
+    assert 'honking' not in repr(sequence + [{'namespaces': 'honking great idea'}])
+    # any mapping-like object should be represented as its keys
+    assert repr(sequence + [{'namespaces': 'honking great idea'}]) == repr(sequence + [confidence.Configuration({'namespaces': 'honking great idea'})])
+
+    assert '[...]' in repr(sequence + [[1, 2, 42]])
+    assert '42' not in repr(sequence + [[1, 2, 42]])
+    # any sequence-like object should be represented as [...]
+    # (this includes a recursive reference, even though that shouldn't happen in practice)
+    assert repr(sequence + [[1, 2, 42]]) == repr(sequence + [(2, 4, 8)]) == repr(sequence + [sequence])

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -95,11 +95,12 @@ def test_addition_wrap(complicated_config):
 def test_repr(complicated_config):
     sequence = complicated_config.different.sequence
 
-    assert 'keys={' not in repr(sequence)
+    assert 'mapping(' not in repr(sequence)
+    assert 'keys=' not in repr(sequence)
     assert '[...]' not in repr(sequence)
     assert '${' in repr(sequence)
 
-    assert 'keys={' in repr(sequence + [{'namespaces': 'honking great idea'}])
+    assert 'mapping(keys=[' in repr(sequence + [{'namespaces': 'honking great idea'}])
     assert 'honking' not in repr(sequence + [{'namespaces': 'honking great idea'}])
     # any mapping-like object should be represented as its keys
     assert repr(sequence + [{'namespaces': 'honking great idea'}]) == repr(sequence + [Configuration({'namespaces': 'honking great idea'})])

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -3,8 +3,7 @@ from os import path
 
 import pytest
 
-import confidence
-from confidence import loadf
+from confidence import Configuration, loadf
 
 
 test_files = path.join(path.dirname(__file__), 'files')
@@ -103,7 +102,7 @@ def test_repr(complicated_config):
     assert 'keys={' in repr(sequence + [{'namespaces': 'honking great idea'}])
     assert 'honking' not in repr(sequence + [{'namespaces': 'honking great idea'}])
     # any mapping-like object should be represented as its keys
-    assert repr(sequence + [{'namespaces': 'honking great idea'}]) == repr(sequence + [confidence.Configuration({'namespaces': 'honking great idea'})])
+    assert repr(sequence + [{'namespaces': 'honking great idea'}]) == repr(sequence + [Configuration({'namespaces': 'honking great idea'})])
 
     assert '[...]' in repr(sequence + [[1, 2, 42]])
     assert '42' not in repr(sequence + [[1, 2, 42]])


### PR DESCRIPTION
Reprs for sequence types were overly verbose (sequence of `Configuration` objects would repeat the module name many times), potential recursive lists would cause breakages.