### PR TITLE
Add optional callback-style way to resolve secret values from config

### DIFF
--- a/confidence/io.py
+++ b/confidence/io.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from string import Formatter
 
 from confidence.formats import YAML, Format
-from confidence.models import Configuration, Missing, NoDefault, NotConfigured
+from confidence.models import Configuration, Missing, NoDefault, NotConfigured, unwrap
+from confidence.secrets import SecretCallback, Secrets, to_secrets
 
 
 LOG = logging.getLogger(__name__)
@@ -234,7 +235,12 @@ DEFAULT_LOAD_ORDER = tuple(
 )
 
 
-def load(*fps: typing.TextIO, format: Format = YAML, missing: typing.Any = Missing.SILENT) -> Configuration:
+def load(
+    *fps: typing.TextIO,
+    format: Format = YAML,
+    missing: typing.Any = Missing.SILENT,
+    secrets: Secrets | SecretCallback | None = None,
+) -> Configuration:
     """
     Read a `Configuration` instance from file-like objects.
 
@@ -242,9 +248,10 @@ def load(*fps: typing.TextIO, format: Format = YAML, missing: typing.Any = Missi
     :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
+    :param secrets: an optional `Secrets` implementation or callback function
     :returns: a `Configuration` instance providing values from *fps*
     """
-    return Configuration(*(format.load(fp) for fp in fps), missing=missing)
+    return Configuration(*(format.load(fp) for fp in fps), missing=missing, secrets=to_secrets(secrets))
 
 
 def loadf(
@@ -252,6 +259,7 @@ def loadf(
     format: Format = YAML,
     default: typing.Any = NoDefault,
     missing: typing.Any = Missing.SILENT,
+    secrets: Secrets | SecretCallback | None = None,
 ) -> Configuration:
     """
     Read a `Configuration` instance from named files.
@@ -262,6 +270,7 @@ def loadf(
         exist (default is to raise a `FileNotFoundError`)
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
+    :param secrets: an optional `Secrets` implementation or callback function
     :returns: a `Configuration` instance providing values from *fnames*
     """
 
@@ -278,10 +287,19 @@ def loadf(
                 return default
 
     # expand the user directories here, format is not in charge of the file paths
-    return Configuration(*(readf(Path(fname).expanduser()) for fname in fnames), missing=missing)
+    return Configuration(
+        *(readf(Path(fname).expanduser()) for fname in fnames),
+        missing=missing,
+        secrets=to_secrets(secrets),
+    )
 
 
-def loads(*strings: str, format: Format = YAML, missing: typing.Any = Missing.SILENT) -> Configuration:
+def loads(
+    *strings: str,
+    format: Format = YAML,
+    missing: typing.Any = Missing.SILENT,
+    secrets: Secrets | SecretCallback | None = None
+) -> Configuration:
     """
     Read a `Configuration` instance from strings.
 
@@ -289,9 +307,14 @@ def loads(*strings: str, format: Format = YAML, missing: typing.Any = Missing.SI
     :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
+    :param secrets: an optional `Secrets` implementation or callback function
     :returns: a `Configuration` instance providing values from *strings*
     """
-    return Configuration(*(format.loads(string) for string in strings), missing=missing)
+    return Configuration(
+        *(format.loads(string) for string in strings),
+        missing=missing,
+        secrets=to_secrets(secrets),
+    )
 
 
 def load_name(
@@ -299,6 +322,7 @@ def load_name(
     load_order: typing.Iterable[Loadable] = DEFAULT_LOAD_ORDER,
     format: Format = YAML,
     missing: typing.Any = Missing.SILENT,
+    secrets: Secrets | SecretCallback | None = None,
     extension: None = None,  # NB: parameter is deprecated, see below
 ) -> Configuration:
     """
@@ -317,6 +341,7 @@ def load_name(
     :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
+    :param secrets: an optional `Secrets` implementation or callback function
     :returns: a `Configuration` instances providing values loaded from *names*
         in *load_order* ordering
     """
@@ -351,7 +376,7 @@ def load_name(
 
                 yield loadf(candidate, format=format, default=NotConfigured)
 
-    return Configuration(*generate_sources(), missing=missing)
+    return Configuration(*generate_sources(), missing=missing, secrets=to_secrets(secrets))
 
 
 def _check_format_encoding(format: Format, encoding: str | None) -> Format:

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from string import Formatter
 
 from confidence.formats import YAML, Format
-from confidence.models import Configuration, Missing, NoDefault, NotConfigured, unwrap
+from confidence.models import Configuration, Missing, NoDefault, NotConfigured
 from confidence.secrets import SecretCallback, Secrets, to_secrets
 
 
@@ -298,7 +298,7 @@ def loads(
     *strings: str,
     format: Format = YAML,
     missing: typing.Any = Missing.SILENT,
-    secrets: Secrets | SecretCallback | None = None
+    secrets: Secrets | SecretCallback | None = None,
 ) -> Configuration:
     """
     Read a `Configuration` instance from strings.

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -51,9 +51,9 @@ def unwrap(source: typing.Any) -> typing.Any:
     return source
 
 
-def merge(*sources: typing.Mapping[str, typing.Any],
-          missing: typing.Any = None,
-          secrets: typing.Any = None) -> 'Configuration':
+def merge(
+    *sources: typing.Mapping[str, typing.Any], missing: typing.Any = None, secrets: typing.Any = None
+) -> 'Configuration':
     """
     Merges *sources* into a union, keeping right-side precedence.
 
@@ -93,7 +93,12 @@ class Configuration(Mapping):
     # match a reference as ${key.to.be.resolved}
     _reference_pattern = re.compile(r'\${(?P<path>[^${}]+?)}')
 
-    def __init__(self, *sources: typing.Mapping[str, typing.Any], missing: typing.Any = Missing.SILENT, secrets: Secrets | None = None):
+    def __init__(
+        self,
+        *sources: typing.Mapping[str, typing.Any],
+        missing: typing.Any = Missing.SILENT,
+        secrets: Secrets | None = None,
+    ):
         """
         Create a new `Configuration`, based on one or multiple source mappings.
 
@@ -112,7 +117,7 @@ class Configuration(Mapping):
                 Missing.ERROR: NoDefault,
             }[missing]
 
-        self._secrets: typing.Optional[Secrets] = secrets
+        self._secrets: Secrets | None = secrets
 
         self._source: typing.MutableMapping[str, typing.Any] = {}
         for source in sources:

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -5,6 +5,7 @@ from enum import Enum
 from itertools import chain
 
 from confidence.exceptions import ConfiguredReferenceError, NotConfiguredError
+from confidence.secrets import Secrets
 from confidence.utils import Conflict, merge_into, split_keys
 
 
@@ -82,7 +83,7 @@ class Configuration(Mapping):
     # match a reference as ${key.to.be.resolved}
     _reference_pattern = re.compile(r'\${(?P<path>[^${}]+?)}')
 
-    def __init__(self, *sources: typing.Mapping[str, typing.Any], missing: typing.Any = Missing.SILENT):
+    def __init__(self, *sources: typing.Mapping[str, typing.Any], missing: typing.Any = Missing.SILENT, secrets: Secrets | None = None):
         """
         Create a new `Configuration`, based on one or multiple source mappings.
 
@@ -90,6 +91,7 @@ class Configuration(Mapping):
             ordered from least to most significant
         :param missing: policy to be used when a configured key is missing,
             either as a `Missing` instance or a default value
+        :param secrets: an optional `Secrets` implementation
         """
         self._missing = missing
         self._root = self
@@ -99,6 +101,8 @@ class Configuration(Mapping):
                 Missing.SILENT: NotConfigured,
                 Missing.ERROR: NoDefault,
             }[missing]
+
+        self._secrets = secrets
 
         self._source: typing.MutableMapping[str, typing.Any] = {}
         for source in sources:

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -117,7 +117,7 @@ class Configuration(Mapping):
 
     def _wrap(self, value: typing.Mapping[str, typing.Any]) -> 'Configuration':
         # create an instance of our current type, copying 'configured' properties / policies
-        namespace = type(self)(missing=self._missing)
+        namespace = type(self)(missing=self._missing, secrets=self._secrets)
         namespace._source = value  # type: ignore  # mutability isn't needed after init
         # carry the root object from namespace to namespace, references are always resolved from root
         namespace._root = self._root

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -59,7 +59,7 @@ def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
         if missing_key := e.args[0] if e.args[0] == single_key else f'{single_key}.{e.args[0]}':
             LOG.warning(f'resolving secret failed, missing key {missing_key}')
         else:
-            LOG.warning(f'resolving secret failed')
+            LOG.warning('resolving secret failed')
         # logging out of the way, there's not actually anything we can do to fix the error here
         # if the caller was Configuration.get(), it will handle the KeyError according to it's policies
         raise

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -6,7 +6,10 @@ import typing
 LOG = logging.getLogger(__name__)
 
 
+# default key for a mapping with a single key that signals being a secret
 DEFAULT_SINGLE_KEY_IDENTIFIER = '$secret'
+# default keys within a secret mapping to be passed to a callback
+# (this deliberately mimics keyring's get_password function)
 DEFAULT_SINGLE_KEY_ARGS = ('service', 'username')
 
 
@@ -46,11 +49,19 @@ def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
                                   single_key: str,
                                   args: typing.Iterable[str]) -> str | None:
     try:
-        secret = value[single_key]
-        return callback(*(secret[arg] for arg in args))
+        mapping = value[single_key]
+        LOG.debug(f'getting values for ({", ".join(args)}) to use as secret retrieval parameters')
+        parameters = tuple(mapping[arg] for arg in args)
+        # logging parameters' *values* might still leak things a user would rather not log
+        LOG.info(f'passing {len(parameters)} to secret callback {callback}')
+        return callback(*parameters)
     except KeyError as e:
-        missing_key = e.args[0] if e.args[0] == single_key else f'{single_key}.{e.args[0]}'
-        LOG.warning(f'resolving secret failed, missing key {missing_key}')
+        if missing_key := e.args[0] if e.args[0] == single_key else f'{single_key}.{e.args[0]}':
+            LOG.warning(f'resolving secret failed, missing key {missing_key}')
+        else:
+            LOG.warning(f'resolving secret failed')
+        # logging out of the way, there's not actually anything we can do to fix the error here
+        # if the caller was Configuration.get(), it will handle the KeyError according to it's policies
         raise
 
 
@@ -59,6 +70,8 @@ class SingleKeyCallback:
                  callback: SecretCallback,
                  single_key: str = DEFAULT_SINGLE_KEY_IDENTIFIER,
                  args: typing.Iterable[str] = DEFAULT_SINGLE_KEY_ARGS):
+        # use is_single_key_secret and resolve_n_key_secret_callback to turn the callback we've been handed here into
+        # something that will implement the Secrets protocol
         self.matches = partial(
             is_single_key_secret,
             key=single_key,

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -1,4 +1,12 @@
+import logging
 import typing
+
+
+LOG = logging.getLogger(__name__)
+
+
+DEFAULT_SINGLE_KEY_IDENTIFIER = '$secret'
+DEFAULT_SINGLE_KEY_ARGS = ('service', 'username')
 
 
 @typing.runtime_checkable
@@ -14,3 +22,23 @@ class Secrets(typing.Protocol):
 class SecretCallback(typing.Protocol):
     def __call__(self, *args: str) -> str | None:
         ...
+
+
+def is_single_key_secret(value: typing.Mapping[str, typing.Any],
+                         *,
+                         key: str) -> bool:
+    return len(value) == 1 and key in value
+
+
+def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
+                                  *,
+                                  callback: SecretCallback,
+                                  single_key: str,
+                                  args: typing.Iterable[str]) -> str | None:
+    try:
+        secret = value[single_key]
+        return callback(*(secret[arg] for arg in args))
+    except KeyError as e:
+        missing_key = e.args[0] if e.args[0] == single_key else f'{single_key}.{e.args[0]}'
+        LOG.warning(f'resolving secret failed, missing key {missing_key}')
+        raise

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -1,6 +1,6 @@
-from functools import partial
 import logging
 import typing
+from functools import partial
 
 
 LOG = logging.getLogger(__name__)
@@ -15,17 +15,14 @@ DEFAULT_SINGLE_KEY_ARGS = ('service', 'username')
 
 @typing.runtime_checkable
 class Secrets(typing.Protocol):
-    def matches(self, value: typing.Mapping[str, typing.Any]) -> bool:
-        ...
+    def matches(self, value: typing.Mapping[str, typing.Any]) -> bool: ...
 
-    def resolve(self, value: typing.Mapping[str, typing.Any]) -> typing.Any:
-        ...
+    def resolve(self, value: typing.Mapping[str, typing.Any]) -> typing.Any: ...
 
 
 @typing.runtime_checkable
 class SecretCallback(typing.Protocol):
-    def __call__(self, *args: str) -> str | None:
-        ...
+    def __call__(self, *args: str) -> str | None: ...
 
 
 def to_secrets(secrets: Secrets | SecretCallback | None) -> Secrets | None:
@@ -37,17 +34,13 @@ def to_secrets(secrets: Secrets | SecretCallback | None) -> Secrets | None:
         return secrets
 
 
-def is_single_key_secret(value: typing.Mapping[str, typing.Any],
-                         *,
-                         key: str) -> bool:
+def is_single_key_secret(value: typing.Mapping[str, typing.Any], *, key: str) -> bool:
     return len(value) == 1 and key in value
 
 
-def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
-                                  *,
-                                  callback: SecretCallback,
-                                  single_key: str,
-                                  args: typing.Iterable[str]) -> str | None:
+def resolve_n_key_secret_callback(
+    value: typing.Mapping[str, typing.Any], *, callback: SecretCallback, single_key: str, args: typing.Iterable[str]
+) -> str | None:
     try:
         mapping = value[single_key]
         LOG.debug(f'getting values for ({", ".join(args)}) to use as secret retrieval parameters')
@@ -66,10 +59,12 @@ def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
 
 
 class SingleKeyCallback:
-    def __init__(self,
-                 callback: SecretCallback,
-                 single_key: str = DEFAULT_SINGLE_KEY_IDENTIFIER,
-                 args: typing.Iterable[str] = DEFAULT_SINGLE_KEY_ARGS):
+    def __init__(
+        self,
+        callback: SecretCallback,
+        single_key: str = DEFAULT_SINGLE_KEY_IDENTIFIER,
+        args: typing.Iterable[str] = DEFAULT_SINGLE_KEY_ARGS,
+    ):
         # use is_single_key_secret and resolve_n_key_secret_callback to turn the callback we've been handed here into
         # something that will implement the Secrets protocol
         self.matches = partial(

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -1,3 +1,4 @@
+from functools import partial
 import logging
 import typing
 
@@ -42,3 +43,20 @@ def resolve_n_key_secret_callback(value: typing.Mapping[str, typing.Any],
         missing_key = e.args[0] if e.args[0] == single_key else f'{single_key}.{e.args[0]}'
         LOG.warning(f'resolving secret failed, missing key {missing_key}')
         raise
+
+
+class SingleKeyCallback:
+    def __init__(self,
+                 callback: SecretCallback,
+                 single_key: str = DEFAULT_SINGLE_KEY_IDENTIFIER,
+                 args: typing.Iterable[str] = DEFAULT_SINGLE_KEY_ARGS):
+        self.matches = partial(
+            is_single_key_secret,
+            key=single_key,
+        )
+        self.resolve = partial(
+            resolve_n_key_secret_callback,
+            callback=callback,
+            single_key=single_key,
+            args=args,
+        )

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -25,6 +25,15 @@ class SecretCallback(typing.Protocol):
         ...
 
 
+def to_secrets(secrets: Secrets | SecretCallback | None) -> Secrets | None:
+    if not secrets:
+        return None
+    elif isinstance(secrets, SecretCallback):
+        return SingleKeyCallback(secrets)
+    else:
+        return secrets
+
+
 def is_single_key_secret(value: typing.Mapping[str, typing.Any],
                          *,
                          key: str) -> bool:

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -1,0 +1,16 @@
+import typing
+
+
+@typing.runtime_checkable
+class Secrets(typing.Protocol):
+    def matches(self, value: typing.Mapping[str, typing.Any]) -> bool:
+        ...
+
+    def resolve(self, value: typing.Mapping[str, typing.Any]) -> typing.Any:
+        ...
+
+
+@typing.runtime_checkable
+class SecretCallback(typing.Protocol):
+    def __call__(self, *args: str) -> str | None:
+        ...

--- a/confidence/secrets.py
+++ b/confidence/secrets.py
@@ -6,23 +6,36 @@ from functools import partial
 LOG = logging.getLogger(__name__)
 
 
-# default key for a mapping with a single key that signals being a secret
-DEFAULT_SINGLE_KEY_IDENTIFIER = '$secret'
-# default keys within a secret mapping to be passed to a callback
-# (this deliberately mimics keyring's get_password function)
-DEFAULT_SINGLE_KEY_ARGS = ('service', 'username')
+@typing.runtime_checkable
+class Secrets(typing.Protocol):
+    def resolve(self, value: typing.Any) -> typing.Any: ...
 
 
 @typing.runtime_checkable
-class Secrets(typing.Protocol):
-    def matches(self, value: typing.Mapping[str, typing.Any]) -> bool: ...
+class MappingSecrets(Secrets, typing.Protocol):
+    # e.g. {"$secret": {"service": "github.com", "username": "akaIDIOT"}}
+    def matches_mapping(self, value: typing.Mapping[str, typing.Any]) -> bool: ...
 
-    def resolve(self, value: typing.Mapping[str, typing.Any]) -> typing.Any: ...
+
+@typing.runtime_checkable
+class SequenceSecrets(Secrets, typing.Protocol):
+    # e.g. ["$secret", "github.com", "akaIDIOT"]  # TODO: references inside of that sequence would likely not work?
+    def matches_sequence(self, value: typing.Sequence[typing.Any]) -> bool: ...
+
+
+@typing.runtime_checkable
+class StrSecrets(Secrets, typing.Protocol):
+    # e.g. "secret!akaIDIOT@github.com"  # TODO: references inside of that str would likely not work?
+    def matches_str(self, value: str) -> bool: ...
 
 
 @typing.runtime_checkable
 class SecretCallback(typing.Protocol):
-    def __call__(self, *args: str) -> str | None: ...
+    def __call__(self, *args: typing.Any) -> typing.Any: ...
+
+
+# FIXME: load_name(..., secrets=keyring.get_password) does not yet specify a matching value (type)
+# FIXME: the rest is very geared towards MappingSecrets
 
 
 def to_secrets(secrets: Secrets | SecretCallback | None) -> Secrets | None:
@@ -40,7 +53,7 @@ def is_single_key_secret(value: typing.Mapping[str, typing.Any], *, key: str) ->
 
 def resolve_n_key_secret_callback(
     value: typing.Mapping[str, typing.Any], *, callback: SecretCallback, single_key: str, args: typing.Iterable[str]
-) -> str | None:
+) -> typing.Any:
     try:
         mapping = value[single_key]
         LOG.debug(f'getting values for ({", ".join(args)}) to use as secret retrieval parameters')
@@ -62,12 +75,12 @@ class SingleKeyCallback:
     def __init__(
         self,
         callback: SecretCallback,
-        single_key: str = DEFAULT_SINGLE_KEY_IDENTIFIER,
-        args: typing.Iterable[str] = DEFAULT_SINGLE_KEY_ARGS,
+        single_key: str = '$secret',
+        args: typing.Iterable[str] = ('service', 'username'),
     ):
         # use is_single_key_secret and resolve_n_key_secret_callback to turn the callback we've been handed here into
         # something that will implement the Secrets protocol
-        self.matches = partial(
+        self.matches_mapping = partial(
             is_single_key_secret,
             key=single_key,
         )


### PR DESCRIPTION
Designed to let `keyring.get_password` drop into any `load*` function or `Configuration` instance, currently based on resolved a sing-magic-key mapping in to a secret value, resolved from the keys inside the mapping:

```yaml
regular.configuration: 42
client:
  username: akaidiot
  password:
    $secret:
      service: github.com
      username: ${client.username}
```

```python
config = load_name(..., secrets=keyring.get_password)
client = Client(**config.client)
```

- [ ] badly needs tests
- [ ] draft, subject to change