### PR TITLE
Separate config file format(s) from I/O

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changes
 development (main)
 ------------------
 
-- Introduce `confidence.Format` with to concrete implementations: `confidence.JSON` and `confidence.YAML`, which can be customized before use (e.g. `format = YAML(suffix='.yml')`).
+- Introduce `confidence.Format` with two concrete implementations: `confidence.JSON` and `confidence.YAML`, which can be customized before use (e.g. `format = YAML(suffix='.yml')`).
 - **Deprecate** the use of `extension` argument to loading functions and `encoding` argument to dumping functions, both can be controlled with a `confidence.Format`.
 
 0.16.1 (2025-08-26)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Changes
 development (main)
 ------------------
 
-
+- Introduce `confidence.Format` with to concrete implementations: `confidence.JSON` and `confidence.YAML`, which can be customized before use (e.g. `format = YAML(suffix='.yml')`).
+- **Deprecate** the use of `extension` argument to loading functions and `encoding` argument to dumping functions, both can be controlled with a `confidence.Format`.
 
 0.16.1 (2025-08-26)
 -------------------

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ configuration = confidence.load_name('app', load_order=confidence.loaders(
     # loading system after user makes system locations take precedence
     confidence.Locality.USER, confidence.Locality.SYSTEM
 ))
+
+# prefer using .yml file names instead? tweak the format:
+
+configuration = confidence.load_name('app', format=YAML('.yml'))
+
+# it doesn't even need to be YAML, JSON is included:
+
+configuration = confidence.load('app', format=JSON('.conf'))
 ~~~~
 
 While powerful, no set of convenience functions will ever satisfy
@@ -91,12 +99,17 @@ def read_from_source(name):
 
 # all of this can be combined to turn it into a single glorious Configuration instance
 # precedence rules apply here, values from read_from_source will overwrite both
-# app_defaults and values read from file
-configuration = confidence.Configuration(app_defaults,
-                                         # yeah, this would be a Configuration instance
-                                         # remember it's just like a dict?
-                                         confidence.loadf('path/to/app.yaml'),
-                                         read_from_source('app'))
+# app_defaults and values read from files (the latter of which will use some 
+# user-supplied Format to read the file)
+configuration = confidence.Configuration(
+    app_defaults,
+    # yeah, these would be a Configuration instances
+    # remember it's just like a dict?
+    confidence.loadf('path/to/app.yaml'),
+    confidence.loadf('another/file/somewhere.ini', format=MyINIFormat),
+    read_from_source('app'),
+)
+
 # make it so, no. 1
 run_app(configuration)
 ~~~~

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from confidence.exceptions import ConfigurationError, ConfiguredReferenceError, MergeConflictError, NotConfiguredError
+from confidence.formats import JSON, YAML, Format
 from confidence.io import DEFAULT_LOAD_ORDER, Locality, dump, dumpf, dumps, load, load_name, loaders, loadf, loads
 from confidence.models import Configuration, Missing, NotConfigured, merge, unwrap
 
@@ -8,9 +9,12 @@ from confidence.models import Configuration, Missing, NotConfigured, merge, unwr
 __all__ = (
     'ConfigurationError',
     'ConfiguredReferenceError',
+    'DEFAULT_LOAD_ORDER',
+    'Format',
+    'JSON',
     'MergeConflictError',
     'NotConfiguredError',
-    'DEFAULT_LOAD_ORDER',
+    'YAML',
     'dump',
     'dumpf',
     'dumps',

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -48,7 +48,6 @@ class _YAMLFormat(Format):
 
 JSON = _JSONFormat('.json')
 YAML = _YAMLFormat('.yaml')
-DEFAULT_FORMAT = YAML
 
 
 __all__ = (

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -1,3 +1,4 @@
+import json
 import typing
 from os import PathLike
 from pathlib import Path
@@ -17,6 +18,16 @@ class Format(typing.Protocol):
     def loadf(self, fpath: typing.Union[str, PathLike], encoding: str = 'utf-8') -> typing.Any:
         with Path(fpath).expanduser().open('rt', encoding=encoding) as fp:
             return self.load(fp)
+
+
+class JSON(Format):
+    extension: typing.Optional[str] = '.json'
+
+    def __init__(self, extension: str = '.json'):
+        self.extension = extension
+
+    def loads(self, string: str) -> typing.Any:
+        return json.loads(string)
 
 
 class YAML(Format):

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -9,7 +9,7 @@ import yaml
 from confidence.models import unwrap
 
 
-@dataclass
+@dataclass(frozen=True)
 class Format(typing.Protocol):
     suffix: str = ''
     encoding: str = 'utf-8'
@@ -40,7 +40,7 @@ class Format(typing.Protocol):
         return replace(self, suffix=suffix)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _JSONFormat(Format):
     suffix: str = '.json'
 
@@ -51,7 +51,7 @@ class _JSONFormat(Format):
         return json.dumps(unwrap(value))
 
 
-@dataclass
+@dataclass(frozen=True)
 class _YAMLFormat(Format):
     suffix: str = '.yaml'
 

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -49,3 +49,10 @@ class _YAMLFormat(Format):
 JSON = _JSONFormat('.json')
 YAML = _YAMLFormat('.yaml')
 DEFAULT_FORMAT = YAML
+
+
+__all__ = (
+    'Format',
+    'JSON',
+    'YAML',
+)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -38,3 +38,6 @@ class YAML(Format):
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)
+
+
+DEFAULT_FORMAT = YAML(extension='.yaml')

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -59,6 +59,8 @@ class _YAMLFormat(Format):
         return yaml.safe_load(string)
 
     def dumps(self, value: typing.Any) -> str:
+        # use block style output for nested collections (flow style dumps nested dicts inline)
+        # omit explicit document end (...) included with simple values
         return yaml.safe_dump(unwrap(value), default_flow_style=False).removesuffix('\n...\n')
 
 

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -1,0 +1,17 @@
+import typing
+from os import PathLike
+from pathlib import Path
+
+
+class Format(typing.Protocol):
+    extension: typing.Optional[str] = None
+
+    def load(self, fp: typing.TextIO) -> typing.Any:
+        return self.loads(fp.read())
+
+    def loads(self, string: str) -> typing.Any:
+        raise NotImplementedError
+
+    def loadf(self, fpath: typing.Union[str, PathLike], encoding: str = 'utf-8') -> typing.Any:
+        with Path(fpath).expanduser().open('rt', encoding=encoding) as fp:
+            return self.load(fp)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -23,7 +23,7 @@ class Format(typing.Protocol):
         raise NotImplementedError
 
     def loadf(self, fpath: typing.Union[str, PathLike], encoding: typing.Optional[str] = None) -> typing.Any:
-        with Path(fpath).expanduser().open('rt', encoding=encoding or self.encoding) as fp:
+        with Path(fpath).open('rt', encoding=encoding or self.encoding) as fp:
             return self.load(fp)
 
     def dump(self, value: typing.Any, fp: typing.TextIO) -> None:

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -7,7 +7,7 @@ import yaml
 
 
 class Format(typing.Protocol):
-    extension: typing.Optional[str] = None
+    extension: str = ''
 
     def load(self, fp: typing.TextIO) -> typing.Any:
         return self.loads(fp.read())
@@ -20,24 +20,26 @@ class Format(typing.Protocol):
             return self.load(fp)
 
 
-class JSON(Format):
-    extension: typing.Optional[str] = '.json'
+class _JSONFormat(Format):
+    extension: str = '.json'
 
-    def __init__(self, extension: str = '.json'):
-        self.extension = extension
+    def __init__(self, extension: typing.Optional[str] = '.json'):
+        self.extension = extension or ''
 
     def loads(self, string: str) -> typing.Any:
         return json.loads(string)
 
 
-class YAML(Format):
-    extension: typing.Optional[str] = '.yaml'
+class _YAMLFormat(Format):
+    extension: str = '.yaml'
 
-    def __init__(self, extension: str = '.yaml'):
-        self.extension = extension
+    def __init__(self, extension: typing.Optional[str] = '.yaml'):
+        self.extension = extension or ''
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)
 
 
-DEFAULT_FORMAT = YAML(extension='.yaml')
+JSON = _JSONFormat('.json')
+YAML = _YAMLFormat('.yaml')
+DEFAULT_FORMAT = YAML

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -62,8 +62,8 @@ class _YAMLFormat(Format):
         return yaml.safe_dump(unwrap(value), default_flow_style=False).removesuffix('\n...\n')
 
 
-JSON: Format = _JSONFormat(suffix='.json')
-YAML: Format = _YAMLFormat(suffix='.yaml')
+JSON: Format = _JSONFormat(suffix='.json', encoding='utf-8')
+YAML: Format = _YAMLFormat(suffix='.yaml', encoding='utf-8')
 
 
 __all__ = (

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import yaml
 
+from confidence import unwrap
+
 
 @dataclass
 class Format(typing.Protocol):
@@ -20,6 +22,16 @@ class Format(typing.Protocol):
     def loadf(self, fpath: typing.Union[str, PathLike], encoding: str = 'utf-8') -> typing.Any:
         with Path(fpath).expanduser().open('rt', encoding=encoding) as fp:
             return self.load(fp)
+
+    def dump(self, value: typing.Any, fp: typing.TextIO) -> None:
+        fp.write(self.dumps(value))
+
+    def dumps(self, value: typing.Any) -> str:
+        raise NotImplementedError
+
+    def dumpf(self, value: typing.Any, fname: typing.Union[str, PathLike]) -> None:
+        with Path(fname).open('wt', encoding='utf-8') as fp:
+            return self.dump(value, fp)
 
     def __call__(self, suffix: str) -> 'Format':  # TODO: replace with typing.Self for Python 3.11+
         return replace(self, suffix=suffix)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -1,5 +1,6 @@
 import json
 import typing
+from abc import abstractmethod
 from dataclasses import dataclass, replace
 from os import PathLike
 from pathlib import Path
@@ -17,6 +18,7 @@ class Format(typing.Protocol):
     def load(self, fp: typing.TextIO) -> typing.Any:
         return self.loads(fp.read())
 
+    @abstractmethod
     def loads(self, string: str) -> typing.Any:
         raise NotImplementedError
 
@@ -27,6 +29,7 @@ class Format(typing.Protocol):
     def dump(self, value: typing.Any, fp: typing.TextIO) -> None:
         fp.write(self.dumps(value))
 
+    @abstractmethod
     def dumps(self, value: typing.Any) -> str:
         raise NotImplementedError
 

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -26,7 +26,7 @@ class _JSONFormat(Format):
     def __init__(self, suffix: typing.Optional[str] = '.json'):
         self.suffix = suffix or ''
 
-    def __call__(self, suffix: str) -> typing.Self:
+    def __call__(self, suffix: str) -> Format:
         return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:
@@ -39,7 +39,7 @@ class _YAMLFormat(Format):
     def __init__(self, suffix: typing.Optional[str] = '.yaml'):
         self.suffix = suffix or ''
 
-    def __call__(self, suffix: str) -> typing.Self:
+    def __call__(self, suffix: str) -> Format:
         return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -26,6 +26,9 @@ class _JSONFormat(Format):
     def __init__(self, extension: typing.Optional[str] = '.json'):
         self.extension = extension or ''
 
+    def __call__(self, extension: str) -> typing.Self:
+        return type(self)(extension)
+
     def loads(self, string: str) -> typing.Any:
         return json.loads(string)
 
@@ -35,6 +38,9 @@ class _YAMLFormat(Format):
 
     def __init__(self, extension: typing.Optional[str] = '.yaml'):
         self.extension = extension or ''
+
+    def __call__(self, extension: str) -> typing.Self:
+        return type(self)(extension)
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -44,6 +44,9 @@ class _JSONFormat(Format):
     def loads(self, string: str) -> typing.Any:
         return json.loads(string)
 
+    def dumps(self, value: typing.Any) -> str:
+        return json.dumps(unwrap(value))
+
 
 @dataclass
 class _YAMLFormat(Format):
@@ -51,6 +54,9 @@ class _YAMLFormat(Format):
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)
+
+    def dumps(self, value: typing.Any) -> str:
+        return yaml.safe_dump(unwrap(value))
 
 
 JSON = _JSONFormat('.json')

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -2,6 +2,8 @@ import typing
 from os import PathLike
 from pathlib import Path
 
+import yaml
+
 
 class Format(typing.Protocol):
     extension: typing.Optional[str] = None
@@ -15,3 +17,13 @@ class Format(typing.Protocol):
     def loadf(self, fpath: typing.Union[str, PathLike], encoding: str = 'utf-8') -> typing.Any:
         with Path(fpath).expanduser().open('rt', encoding=encoding) as fp:
             return self.load(fp)
+
+
+class YAML(Format):
+    extension: typing.Optional[str] = '.yaml'
+
+    def __init__(self, extension: str = '.yaml'):
+        self.extension = extension
+
+    def loads(self, string: str) -> typing.Any:
+        return yaml.safe_load(string)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -36,8 +36,8 @@ class Format(typing.Protocol):
         with Path(fname).open('wt', encoding=encoding or self.encoding) as fp:
             return self.dump(value, fp)
 
-    def __call__(self, suffix: str) -> 'Format':  # TODO: replace with typing.Self for Python 3.11+
-        return replace(self, suffix=suffix)
+    def __call__(self, **kwargs: typing.Any) -> 'Format':  # TODO: replace with typing.Self for Python 3.11+
+        return replace(self, **kwargs)
 
 
 @dataclass(frozen=True)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -1,11 +1,13 @@
 import json
 import typing
+from dataclasses import dataclass, replace
 from os import PathLike
 from pathlib import Path
 
 import yaml
 
 
+@dataclass
 class Format(typing.Protocol):
     suffix: str = ''
 
@@ -19,28 +21,21 @@ class Format(typing.Protocol):
         with Path(fpath).expanduser().open('rt', encoding=encoding) as fp:
             return self.load(fp)
 
+    def __call__(self, suffix: str) -> 'Format':  # TODO: replace with typing.Self for Python 3.11+
+        return replace(self, suffix=suffix)
 
+
+@dataclass
 class _JSONFormat(Format):
     suffix: str = '.json'
-
-    def __init__(self, suffix: typing.Optional[str] = '.json'):
-        self.suffix = suffix or ''
-
-    def __call__(self, suffix: str) -> Format:
-        return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:
         return json.loads(string)
 
 
+@dataclass
 class _YAMLFormat(Format):
     suffix: str = '.yaml'
-
-    def __init__(self, suffix: typing.Optional[str] = '.yaml'):
-        self.suffix = suffix or ''
-
-    def __call__(self, suffix: str) -> Format:
-        return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -1,6 +1,6 @@
 import json
 import typing
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from os import PathLike
 from pathlib import Path
@@ -11,7 +11,7 @@ from confidence.models import unwrap
 
 
 @dataclass(frozen=True)
-class Format(typing.Protocol):
+class Format(ABC):
     suffix: str = ''
     encoding: str = 'utf-8'
 

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -7,7 +7,7 @@ import yaml
 
 
 class Format(typing.Protocol):
-    extension: str = ''
+    suffix: str = ''
 
     def load(self, fp: typing.TextIO) -> typing.Any:
         return self.loads(fp.read())
@@ -21,26 +21,26 @@ class Format(typing.Protocol):
 
 
 class _JSONFormat(Format):
-    extension: str = '.json'
+    suffix: str = '.json'
 
-    def __init__(self, extension: typing.Optional[str] = '.json'):
-        self.extension = extension or ''
+    def __init__(self, suffix: typing.Optional[str] = '.json'):
+        self.suffix = suffix or ''
 
-    def __call__(self, extension: str) -> typing.Self:
-        return type(self)(extension)
+    def __call__(self, suffix: str) -> typing.Self:
+        return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:
         return json.loads(string)
 
 
 class _YAMLFormat(Format):
-    extension: str = '.yaml'
+    suffix: str = '.yaml'
 
-    def __init__(self, extension: typing.Optional[str] = '.yaml'):
-        self.extension = extension or ''
+    def __init__(self, suffix: typing.Optional[str] = '.yaml'):
+        self.suffix = suffix or ''
 
-    def __call__(self, extension: str) -> typing.Self:
-        return type(self)(extension)
+    def __call__(self, suffix: str) -> typing.Self:
+        return type(self)(suffix)
 
     def loads(self, string: str) -> typing.Any:
         return yaml.safe_load(string)

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -8,10 +8,8 @@ from itertools import product
 from os import PathLike, environ, pathsep
 from pathlib import Path
 
-import yaml
-
 from confidence.formats import YAML, Format
-from confidence.models import Configuration, Missing, NoDefault, NotConfigured, unwrap
+from confidence.models import Configuration, Missing, NoDefault, NotConfigured
 
 
 LOG = logging.getLogger(__name__)
@@ -344,40 +342,22 @@ def load_name(
     return Configuration(*generate_sources(), missing=missing)
 
 
-def dump(value: typing.Any, fp: typing.IO, encoding: str = 'utf-8') -> None:
+def dump(value: typing.Any, fp: typing.TextIO, format: Format = YAML, encoding: str = 'utf-8') -> None:
     """
-    Serialize the configuration in *value* to YAML format, writing it to *fp*.
-
-    :param value: the value (like a `Configuration` object) to dump
-    :param fp: a file-like object to write to
-    :param encoding: encoding to use
+    Shorthand for `format.dump(value, fp)`.
     """
-    # recursively unwrap the value to help yaml understand what we're trying to dump
-    # use block style output for nested collections (flow style dumps nested dicts inline)
-    yaml.safe_dump(unwrap(value), stream=fp, encoding=encoding, default_flow_style=False)
+    format.dump(value, fp)
 
 
-def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], encoding: str = 'utf-8') -> None:
+def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], format: Format = YAML, encoding: str = 'utf-8') -> None:
     """
-    Serialize the configuration in *value* to a YAML-formatted file.
-
-    :param value: the value (like a `Configuration` object) to dump
-    :param fname: name or path of the file to write to
-    :param encoding: encoding to use
+    Shorthand for `format.dumpf(value, fname)`.
     """
-    with Path(fname).open('wb') as out_file:
-        dump(value, out_file, encoding=encoding)
+    format.dumpf(value, fname)
 
 
-def dumps(value: typing.Any) -> str:
+def dumps(value: typing.Any, format: Format = YAML) -> str:
     """
-    Serialize the configuration in *value* as a YAML-formatted string.
-
-    :param value: the value (like a `Configuration` object) to dump
-    :returns: *configuration*, serialized as a `str` in YAML format
+    Shorthand for `format.dumps(value)`.
     """
-    # recursively unwrap the value to help yaml understand what we're trying to dump
-    # use block style output for nested collections (flow style dumps nested dicts inline)
-    encoded = yaml.safe_dump(unwrap(value), default_flow_style=False)
-    # omit explicit document end (...) included with simple values
-    return encoded.removesuffix('\n...\n')
+    return format.dumps(value)

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -122,17 +122,17 @@ def read_envvar_file(name: str, format: Format = YAML) -> Configuration:
         return NotConfigured
 
 
-def read_envvar_dir(envvar: str, name: str, extension: str) -> Configuration:
+def read_envvar_dir(envvar: str, name: str, format: Format = YAML) -> Configuration:
     """
     Read values from a file located in a directory specified by a particular
-    environment file. ``read_envvar_dir('HOME', 'example', 'yaml')`` would
+    environment file. ``read_envvar_dir('HOME', 'example', format=YAML)`` would
     look for a file at ``/home/user/example.yaml``. When the environment
     variable isn't set or the file does not exist, `NotConfigured` will be
     returned.
 
     :param envvar: the environment variable to interpret as a directory
     :param name: application or configuration set name
-    :param extension: file extension to look for
+    :param format: configuration (file) format to use
     :returns: a `Configuration`, possibly `NotConfigured`
     """
     config_dir = environ.get(envvar)
@@ -140,8 +140,8 @@ def read_envvar_dir(envvar: str, name: str, extension: str) -> Configuration:
         return NotConfigured
 
     # envvar is set, construct full file path, expanding user to allow the envvar containing a value like ~/config
-    config_path = Path(config_dir).expanduser() / f'{name}.{extension}'
-    return loadf(config_path, default=NotConfigured)
+    config_path = Path(config_dir).expanduser() / f'{name}{format.suffix}'
+    return loadf(config_path, format=format, default=NotConfigured)
 
 
 class Locality(IntEnum):

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -297,8 +297,8 @@ def load_name(
     *names: str,
     load_order: typing.Iterable[Loadable] = DEFAULT_LOAD_ORDER,
     format: Format = YAML,
-    extension: None = None,
     missing: typing.Any = Missing.SILENT,
+    extension: None = None,  # NB: parameter is deprecated, see below
 ) -> Configuration:
     """
     Read a `Configuration` instance by name, trying to read from files in
@@ -358,7 +358,12 @@ def _check_format_encoding(format: Format, encoding: typing.Optional[str]) -> Fo
     return format
 
 
-def dump(value: typing.Any, fp: typing.TextIO, format: Format = YAML, encoding: None = None) -> None:
+def dump(
+    value: typing.Any,
+    fp: typing.TextIO,
+    format: Format = YAML,
+    encoding: None = None,  # NB: parameter is deprecated, see _check_format_encoding
+) -> None:
     """
     Shorthand for `format.dump(value, fp)`.
     """
@@ -366,7 +371,12 @@ def dump(value: typing.Any, fp: typing.TextIO, format: Format = YAML, encoding: 
     format.dump(value, fp)
 
 
-def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], format: Format = YAML, encoding: None = None) -> None:
+def dumpf(
+    value: typing.Any,
+    fname: typing.Union[str, PathLike],
+    format: Format = YAML,
+    encoding: None = None,  # NB: parameter is deprecated, see _check_format_encoding
+) -> None:
     """
     Shorthand for `format.dumpf(value, fname)`.
     """

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -319,8 +319,7 @@ def load_name(
             if callable(source):
                 yield source(name, extension)
             else:
-                # expand user to turn ~/.name.yaml into /home/user/.name.yaml
-                candidate = Path(source.format(name=name, extension=extension)).expanduser()
+                candidate = Path(source.format(name=name, suffix=format.suffix))
                 yield loadf(candidate, default=NotConfigured)
 
     return Configuration(*generate_sources(), missing=missing)

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -324,7 +324,7 @@ def load_name(
                 category=DeprecationWarning,
                 stacklevel=2,  # warn about user code calling load_name rather than load_name itself`
             )
-            format = YAML(f'.{extension}')
+            format = YAML(suffix=f'.{extension}')
         else:
             raise ValueError("format and extension cannot be combined, use format's suffix")
 
@@ -342,17 +342,34 @@ def load_name(
     return Configuration(*generate_sources(), missing=missing)
 
 
-def dump(value: typing.Any, fp: typing.TextIO, format: Format = YAML, encoding: str = 'utf-8') -> None:
+def _check_format_encoding(format: Format, encoding: typing.Optional[str]) -> Format:
+    if encoding:
+        if format is YAML:
+            warnings.warn(
+                'encoding argument to dump functions has been deprecated, use the format argument to set the encoding',
+                category=DeprecationWarning,
+                stacklevel=3,
+            )
+            return format(encoding=encoding)
+        else:
+            raise ValueError("format and encoding cannot be combined, use format's encoding")
+
+    return format
+
+
+def dump(value: typing.Any, fp: typing.TextIO, format: Format = YAML, encoding: None = None) -> None:
     """
     Shorthand for `format.dump(value, fp)`.
     """
+    format = _check_format_encoding(format, encoding)
     format.dump(value, fp)
 
 
-def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], format: Format = YAML, encoding: str = 'utf-8') -> None:
+def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], format: Format = YAML, encoding: None = None) -> None:
     """
     Shorthand for `format.dumpf(value, fname)`.
     """
+    format = _check_format_encoding(format, encoding)
     format.dumpf(value, fname)
 
 

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -157,30 +157,30 @@ class Locality(IntEnum):
     ENVIRONMENT = 3  #: configuration from environment variables
 
 
-Loadable = typing.Union[str, typing.Callable[[str, str], Configuration]]
+Loadable = typing.Union[str, typing.Callable[[str, Format], Configuration]]
 
 
 _LOADERS: typing.Mapping[Locality, typing.Iterable[Loadable]] = {
     Locality.SYSTEM: (
         # system-wide locations
         read_xdg_config_dirs,
-        '/etc/{name}/{name}.{extension}',
-        '/etc/{name}.{extension}',
-        '/Library/Preferences/{name}/{name}.{extension}',
-        '/Library/Preferences/{name}.{extension}',
+        '/etc/{name}/{name}{suffix}',
+        '/etc/{name}{suffix}',
+        '/Library/Preferences/{name}/{name}{suffix}',
+        '/Library/Preferences/{name}{suffix}',
         partial(read_envvar_dir, 'PROGRAMDATA'),
     ),
     Locality.USER: (
         # user-local locations
         read_xdg_config_home,
-        '~/Library/Preferences/{name}.{extension}',
+        '~/Library/Preferences/{name}{suffix}',
         partial(read_envvar_dir, 'APPDATA'),
         partial(read_envvar_dir, 'LOCALAPPDATA'),
-        '~/.{name}.{extension}',
+        '~/.{name}{suffix}',
     ),
     Locality.APPLICATION: (
         # application-local locations
-        './{name}.{extension}',
+        './{name}{suffix}',
     ),
     Locality.ENVIRONMENT: (
         # application-specific environment variables
@@ -204,7 +204,7 @@ def loaders(*specifiers: typing.Union[Locality, Loadable]) -> typing.Iterable[Lo
         # an explicit path, a template and a user-defined function
         load_order = loaders(Locality.user,
                              '/etc/defaults/hard-coded.yaml',
-                             '/path/to/{name}.{extension}',
+                             '/path/to/{name}{suffix}',
                              my_loader)
 
         # load configuration for name 'my-application' using the load order

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -40,14 +40,14 @@ def read_xdg_config_dirs(name: str, format: Format = YAML) -> Configuration:
     )
 
 
-def read_xdg_config_home(name: str, extension: str) -> Configuration:
+def read_xdg_config_home(name: str, format: Format = YAML) -> Configuration:
     """
     Read from file found in XDG-specified configuration home directory,
     expanding to ``${HOME}/.config/name.extension`` by default. Depends on
     ``XDG_CONFIG_HOME`` or ``HOME`` environment variables.
 
     :param name: application or configuration set name
-    :param extension: file extension to look for
+    :param format: configuration (file) format to use
     :returns: a `Configuration` instance, possibly `NotConfigured`
     """
     # find optional value of ${XDG_CONFIG_HOME}
@@ -56,7 +56,7 @@ def read_xdg_config_home(name: str, extension: str) -> Configuration:
     config_home = environ.get('XDG_CONFIG_HOME')
     config_home = Path(config_home) if config_home else Path('~/.config').expanduser()
     # expand to full path to configuration file in XDG config path
-    return loadf(config_home / f'{name}.{extension}', default=NotConfigured)
+    return loadf(config_home / f'{name}{format.suffix}', format=format, default=NotConfigured)
 
 
 def read_envvars(name: str, extension: typing.Optional[str] = None) -> Configuration:

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -103,20 +103,20 @@ def read_envvars(name: str, format: Format = YAML) -> Configuration:
     return Configuration({dotted(name): format.loads(value) for name, value in values.items()})
 
 
-def read_envvar_file(name: str, extension: typing.Optional[str] = None) -> Configuration:
+def read_envvar_file(name: str, format: Format = YAML) -> Configuration:
     """
     Read values from a file provided as a environment variable
     ``NAME_CONFIG_FILE``.
 
     :param name: environment variable prefix to look for (without the
         ``_CONFIG_FILE``)
-    :param extension: *(unused)*
+    :param format: configuration (file) format to use
     :returns: a `Configuration`, possibly `NotConfigured`
     """
     envvar_file = environ.get(f'{name}_config_file'.upper())
     if envvar_file:
         # envvar set, load value as file
-        return loadf(envvar_file)
+        return loadf(envvar_file, format=format)
     else:
         # envvar not set, return an empty source
         return NotConfigured

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -323,7 +323,7 @@ def load_name(
         if format is YAML:
             warnings.warn(
                 'extension argument to load_name has been deprecated, use the format argument to set the file suffix',
-                DeprecationWarning,
+                category=DeprecationWarning,
                 stacklevel=2,  # warn about user code calling load_name rather than load_name itself`
             )
             format = YAML(f'.{extension}')

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import typing
+import warnings
 from enum import IntEnum
 from functools import partial
 from itertools import product
@@ -318,6 +319,16 @@ def load_name(
     :returns: a `Configuration` instances providing values loaded from *names*
         in *load_order* ordering
     """
+    if extension is not None:
+        if format is YAML:
+            warnings.warn(
+                'extension argument to load_name has been deprecated, use the format argument to set the file suffix',
+                DeprecationWarning,
+                stacklevel=2,  # warn about user code calling load_name rather than load_name itself`
+            )
+            format = YAML(f'.{extension}')
+        else:
+            raise ValueError("format and extension cannot be combined, use format's suffix")
 
     def generate_sources() -> typing.Iterable[typing.Mapping[str, typing.Any]]:
         # argument order for product matters, for names "foo" and "bar":

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -295,7 +295,8 @@ def loads(*strings: str, format: Format = YAML, missing: typing.Any = Missing.SI
 def load_name(
     *names: str,
     load_order: typing.Iterable[Loadable] = DEFAULT_LOAD_ORDER,
-    extension: str = 'yaml',
+    format: Format = YAML,
+    extension: None = None,
     missing: typing.Any = Missing.SILENT,
 ) -> Configuration:
     """
@@ -311,7 +312,7 @@ def load_name(
         significance
     :param load_order: ordered list of name templates or `callable` s, in
         increasing order of significance
-    :param extension: file extension to be used
+    :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
     :returns: a `Configuration` instances providing values loaded from *names*
@@ -323,10 +324,11 @@ def load_name(
         # /etc/foo.yaml before /etc/bar.yaml, but both of them before ~/.foo.yaml and ~/.bar.yaml
         for source, name in product(load_order, names):
             if callable(source):
-                yield source(name, extension)
+                yield source(name, format)
             else:
-                candidate = Path(source.format(name=name, suffix=format.suffix))
-                yield loadf(candidate, default=NotConfigured)
+                # TODO: should expanduser be called here?
+                candidate = Path(source.format(name=name, suffix=format.suffix)).expanduser()
+                yield loadf(candidate, format=format, default=NotConfigured)
 
     return Configuration(*generate_sources(), missing=missing)
 

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -59,7 +59,7 @@ def read_xdg_config_home(name: str, format: Format = YAML) -> Configuration:
     return loadf(config_home / f'{name}{format.suffix}', format=format, default=NotConfigured)
 
 
-def read_envvars(name: str, extension: typing.Optional[str] = None) -> Configuration:
+def read_envvars(name: str, format: Format = YAML) -> Configuration:
     """
     Read environment variables starting with ``NAME_``, where subsequent
     underscores are interpreted as namespaces. Underscores can be retained as
@@ -75,7 +75,7 @@ def read_envvars(name: str, extension: typing.Optional[str] = None) -> Configura
         `.read_envvar_file`.
 
     :param name: environment variable prefix to look for (without the ``_``)
-    :param extension: *(unused)*
+    :param format: configuration (file) format to use
     :returns: a `Configuration` instance, possibly `NotConfigured`
     """
     prefix = f'{name}_'
@@ -100,7 +100,7 @@ def read_envvars(name: str, extension: typing.Optional[str] = None) -> Configura
     LOG.info(f'reading configuration from {len(values)} {prefix}* environment variables')
 
     # pass value to yaml.safe_load to align data type transformation with reading values from files
-    return Configuration({dotted(name): yaml.safe_load(value) for name, value in values.items()})
+    return Configuration({dotted(name): format.loads(value) for name, value in values.items()})
 
 
 def read_envvar_file(name: str, extension: typing.Optional[str] = None) -> Configuration:

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -16,14 +16,14 @@ from confidence.models import Configuration, Missing, NoDefault, NotConfigured, 
 LOG = logging.getLogger(__name__)
 
 
-def read_xdg_config_dirs(name: str, extension: str) -> Configuration:
+def read_xdg_config_dirs(name: str, format: Format = YAML) -> Configuration:
     """
     Read from files found in XDG-specified system-wide configuration paths,
     defaulting to ``/etc/xdg``. Depends on ``XDG_CONFIG_DIRS`` environment
     variable.
 
     :param name: application or configuration set name
-    :param extension: file extension to look for
+    :param format: configuration (file) format to use
     :returns: a `Configuration` instance with values read from XDG-specified
         directories
     """
@@ -33,7 +33,11 @@ def read_xdg_config_dirs(name: str, extension: str) -> Configuration:
     config_dirs = reversed(config_dirs.split(pathsep))
 
     # load a file from all config dirs, default to NotConfigured
-    return loadf(*(Path(config_dir) / f'{name}.{extension}' for config_dir in config_dirs), default=NotConfigured)
+    return loadf(
+        *(Path(config_dir) / f'{name}{format.suffix}' for config_dir in config_dirs),
+        format=format,
+        default=NotConfigured,
+    )
 
 
 def read_xdg_config_home(name: str, extension: str) -> Configuration:

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -51,9 +51,10 @@ def read_xdg_config_home(name: str, format: Format = YAML) -> Configuration:
     """
     # find optional value of ${XDG_CONFIG_HOME}
     # XDG spec: "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
-    # see https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
+    # see https://specifications.freedesktop.org/basedir-spec/latest/
+    home = environ.get('HOME')
     config_home = environ.get('XDG_CONFIG_HOME')
-    config_home = Path(config_home) if config_home else Path('~/.config').expanduser()
+    config_home = Path(config_home) if config_home else Path(f'{home}/.config')
     # expand to full path to configuration file in XDG config path
     return loadf(config_home / f'{name}{format.suffix}', format=format, default=NotConfigured)
 

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -275,7 +275,8 @@ def loadf(
                 LOG.debug(f'unable to read configuration from file {fpath}')
                 return default
 
-    return Configuration(*(readf(Path(fname)) for fname in fnames), missing=missing)
+    # expand the user directories here, format is not in charge of the file paths
+    return Configuration(*(readf(Path(fname).expanduser()) for fname in fnames), missing=missing)
 
 
 def loads(*strings: str, format: Format = YAML, missing: typing.Any = Missing.SILENT) -> Configuration:
@@ -335,8 +336,7 @@ def load_name(
             if callable(source):
                 yield source(name, format)
             else:
-                # TODO: should expanduser be called here?
-                candidate = Path(source.format(name=name, suffix=format.suffix)).expanduser()
+                candidate = Path(source.format(name=name, suffix=format.suffix))
                 yield loadf(candidate, format=format, default=NotConfigured)
 
     return Configuration(*generate_sources(), missing=missing)
@@ -370,7 +370,8 @@ def dumpf(value: typing.Any, fname: typing.Union[str, PathLike], format: Format 
     Shorthand for `format.dumpf(value, fname)`.
     """
     format = _check_format_encoding(format, encoding)
-    format.dumpf(value, fname)
+    # expand the dump path here, format is not in charge of the file paths
+    format.dumpf(value, Path(fname).expanduser())
 
 
 def dumps(value: typing.Any, format: Format = YAML) -> str:

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -233,16 +233,17 @@ DEFAULT_LOAD_ORDER = tuple(
 )
 
 
-def load(*fps: typing.IO, missing: typing.Any = Missing.SILENT) -> Configuration:
+def load(*fps: typing.TextIO, format: Format = YAML, missing: typing.Any = Missing.SILENT) -> Configuration:
     """
     Read a `Configuration` instance from file-like objects.
 
     :param fps: file-like objects (supporting ``.read()``)
+    :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
     :returns: a `Configuration` instance providing values from *fps*
     """
-    return Configuration(*(yaml.safe_load(fp.read()) for fp in fps), missing=missing)
+    return Configuration(*(format.load(fp) for fp in fps), missing=missing)
 
 
 def loadf(

--- a/confidence/io.py
+++ b/confidence/io.py
@@ -279,16 +279,17 @@ def loadf(
     return Configuration(*(readf(Path(fname)) for fname in fnames), missing=missing)
 
 
-def loads(*strings: str, missing: typing.Any = Missing.SILENT) -> Configuration:
+def loads(*strings: str, format: Format = YAML, missing: typing.Any = Missing.SILENT) -> Configuration:
     """
     Read a `Configuration` instance from strings.
 
     :param strings: configuration contents
+    :param format: configuration (file) format to use
     :param missing: policy to be used when a configured key is missing, either
         as a `Missing` instance or a default value
     :returns: a `Configuration` instance providing values from *strings*
     """
-    return Configuration(*(yaml.safe_load(string) for string in strings), missing=missing)
+    return Configuration(*(format.loads(string) for string in strings), missing=missing)
 
 
 def load_name(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,8 @@ allow_untyped_defs = false
 strict_optional = true
 # warn about lines in this file that make no sense to mypy
 warn_unused_configs = true
+
+[tool.coverage.report]
+exclude_also = [
+    "raise NotImplementedError",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ update-lock = "pdm lock --group :all"
 [tool.ruff]
 format.quote-style = "single"
 line-length = 120
+lint.flake8-builtins.ignorelist = ["format"]
 lint.flake8-quotes.inline-quotes = "single"
 lint.ignore = [
     # enforced by the formatter, not ignoring this causes warnings

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,32 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from confidence.formats import JSON, YAML
+
+
+@pytest.mark.parametrize('format', (JSON, YAML))
+@pytest.mark.parametrize('value', (None, True, 1, 42.0, 'a string'))
+def test_singular_value_roundtrip(format, value):
+    assert format.loads(format.dumps(value)) == value
+
+
+@pytest.mark.parametrize('format', (JSON, YAML, YAML(suffix='.conf', encoding='utf-32')))
+@pytest.mark.parametrize('value', ([], {}, [1, 2, 'a'], {'a': 1, 'b': 42.0, 'c': {'d': 'str'}}))
+def test_multiple_values_roundtrip(format, value, tmp_path):
+    fname = tmp_path / f'config{format.suffix}'
+
+    format.dumpf(value, fname)
+    assert format.loadf(fname) == value
+
+
+def test_edit_format():
+    format = JSON(encoding='iso-8859-1')
+
+    assert format is not JSON
+    assert format != JSON
+    assert format.encoding == 'iso-8859-1'
+    assert format == JSON(suffix='.json', encoding='iso-8859-1')
+
+    with pytest.raises(FrozenInstanceError):
+        YAML.suffix = '.yml'

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,6 +19,7 @@ from confidence import (
     loadf,
     loads,
 )
+from confidence.formats import JSON, YAML
 from confidence.io import dumpf, dumps, read_envvar_file, read_envvars, read_xdg_config_dirs, read_xdg_config_home
 
 
@@ -172,14 +173,14 @@ def test_loadf_empty(test_files):
 
 
 def test_load_name_single(test_files):
-    test_path = path.join(test_files, '{name}.{extension}')
+    test_path = path.join(test_files, '{name}{suffix}')
 
     _assert_values(load_name('config', load_order=(test_path,)))
-    _assert_values(load_name('config', load_order=(test_path,), extension='json'))
+    _assert_values(load_name('config', load_order=(test_path,), format=JSON))
 
 
 def test_load_name_multiple(test_files):
-    test_path = path.join(test_files, '{name}.{extension}')
+    test_path = path.join(test_files, '{name}{suffix}')
 
     # bar has precedence over foo
     subject = load_name('foo', 'fake', 'bar', load_order=(test_path,))
@@ -209,26 +210,26 @@ def test_load_name_order(tilde_home_user):
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('/etc/xdg/foo.yaml'), default=NotConfigured),
-            call(Path('/etc/xdg/bar.yaml'), default=NotConfigured),
-            call(Path('/etc/foo/foo.yaml'), default=NotConfigured),
-            call(Path('/etc/bar/bar.yaml'), default=NotConfigured),
-            call(Path('/etc/foo.yaml'), default=NotConfigured),
-            call(Path('/etc/bar.yaml'), default=NotConfigured),
-            call(Path('/Library/Preferences/foo/foo.yaml'), default=NotConfigured),
-            call(Path('/Library/Preferences/bar/bar.yaml'), default=NotConfigured),
-            call(Path('/Library/Preferences/foo.yaml'), default=NotConfigured),
-            call(Path('/Library/Preferences/bar.yaml'), default=NotConfigured),
-            call(Path('/home/user/.config/foo.yaml'), default=NotConfigured),
-            call(Path('/home/user/.config/bar.yaml'), default=NotConfigured),
-            call(Path('/home/user/Library/Preferences/foo.yaml'), default=NotConfigured),
-            call(Path('/home/user/Library/Preferences/bar.yaml'), default=NotConfigured),
-            call(Path('C:/Users/user/AppData/Local/foo.yaml'), default=NotConfigured),
-            call(Path('C:/Users/user/AppData/Local/bar.yaml'), default=NotConfigured),
-            call(Path('/home/user/.foo.yaml'), default=NotConfigured),
-            call(Path('/home/user/.bar.yaml'), default=NotConfigured),
-            call(Path('./foo.yaml'), default=NotConfigured),
-            call(Path('./bar.yaml'), default=NotConfigured),
+            call(Path('/etc/xdg/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/xdg/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/foo/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/bar/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/Library/Preferences/foo/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/Library/Preferences/bar/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/Library/Preferences/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/Library/Preferences/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.config/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.config/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/Library/Preferences/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/Library/Preferences/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('C:/Users/user/AppData/Local/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('C:/Users/user/AppData/Local/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('./foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('./bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )
@@ -247,8 +248,8 @@ def test_load_name_xdg_config_dirs():
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('/etc/not-xdg/foo.yaml'), Path('/etc/xdg-desktop/foo.yaml'), default=NotConfigured),
-            call(Path('/etc/not-xdg/bar.yaml'), Path('/etc/xdg-desktop/bar.yaml'), default=NotConfigured),
+            call(Path('/etc/not-xdg/foo.yaml'), Path('/etc/xdg-desktop/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/not-xdg/bar.yaml'), Path('/etc/xdg-desktop/bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )
@@ -263,8 +264,8 @@ def test_load_name_xdg_config_dirs_fallback():
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('/etc/xdg/foo.yaml'), default=NotConfigured),
-            call(Path('/etc/xdg/bar.yaml'), default=NotConfigured),
+            call(Path('/etc/xdg/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/etc/xdg/bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )
@@ -281,8 +282,8 @@ def test_load_name_xdg_config_home(tilde_home_user):
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('/home/user/.not-config/foo.yaml'), default=NotConfigured),
-            call(Path('/home/user/.not-config/bar.yaml'), default=NotConfigured),
+            call(Path('/home/user/.not-config/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.not-config/bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )
@@ -299,8 +300,8 @@ def test_load_name_xdg_config_home_fallback(tilde_home_user):
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('/home/user/.config/foo.yaml'), default=NotConfigured),
-            call(Path('/home/user/.config/bar.yaml'), default=NotConfigured),
+            call(Path('/home/user/.config/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('/home/user/.config/bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )
@@ -378,10 +379,10 @@ def test_load_name_envvar_dir(tilde_home_user):
 
     mocked_loadf.assert_has_calls(
         [
-            call(Path('C:/ProgramData/foo.yaml'), default=NotConfigured),
-            call(Path('C:/ProgramData/bar.yaml'), default=NotConfigured),
-            call(Path('D:/Users/user/AppData/Roaming/foo.yaml'), default=NotConfigured),
-            call(Path('D:/Users/user/AppData/Roaming/bar.yaml'), default=NotConfigured),
+            call(Path('C:/ProgramData/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('C:/ProgramData/bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('D:/Users/user/AppData/Roaming/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('D:/Users/user/AppData/Roaming/bar.yaml'), format=YAML, default=NotConfigured),
         ],
         any_order=False,
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -402,14 +402,8 @@ def test_load_name_envvar_dir(tilde_home_user):
 def test_load_name_deprecated_extension():
     loader = MagicMock()
 
-    with patch('confidence.io.warnings') as warnings:
+    with pytest.warns(DeprecationWarning, match='extension argument'):
         load_name('app', extension='yml', load_order=[loader])
-
-    warnings.warn.assert_called_once_with(
-        str_containing('extension argument'),
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
     loader.assert_called_once_with('app', YAML(suffix='.yml'))
 
     with pytest.raises(ValueError, match='format and extension'):
@@ -465,14 +459,8 @@ def test_dumpf_roundtrip(value, tmp_path):
 
 
 def test_dumpf_deprecated_encoding(tmp_path):
-    with patch('confidence.io.warnings') as warnings:
+    with pytest.warns(DeprecationWarning, match='encoding argument'):
         dumpf({'a': 1}, tmp_path / 'dumpf.yaml', encoding='utf-32')
-
-    warnings.warn.assert_called_once_with(
-        str_containing('encoding argument to dump functions'),
-        category=DeprecationWarning,
-        stacklevel=3,
-    )
 
     with pytest.raises(ValueError, match="use format's encoding"):
         dumpf({'a': 1}, tmp_path / 'dumpf.yaml', format=JSON, encoding='utf-32')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -200,13 +200,20 @@ def test_load_name_multiple(test_files):
 
 
 def test_load_name_order(tilde_home_user):
-    env = {'HOME': '/home/user', 'LOCALAPPDATA': 'C:/Users/user/AppData/Local'}
+    env = {
+        'HOME': '/home/user',
+        'LOCALAPPDATA': 'C:/Users/user/AppData/Local',
+        'FOO_TEST': '21',
+        'BAR_TEST': '42',
+    }
 
     with (
         patch('confidence.io.environ', env),
         patch('confidence.io.loadf', return_value=NotConfigured) as mocked_loadf,
     ):
-        assert len(load_name('foo', 'bar')) == 0
+        subject = load_name('foo', 'bar')
+        assert len(subject) == 1
+        assert subject.test == 42
 
     mocked_loadf.assert_has_calls(
         [

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@
 from functools import partial
 from os import path
 from pathlib import Path
-from unittest.mock import call, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 import yaml
@@ -393,6 +393,23 @@ def test_load_name_envvar_dir(tilde_home_user):
         ],
         any_order=False,
     )
+
+
+def test_load_name_deprecated_extension():
+    loader = MagicMock()
+
+    with patch('confidence.io.warnings') as warnings:
+        load_name('app', extension='yml', load_order=[loader])
+
+    warnings.warn.assert_called_once_with(
+        str_containing('extension argument'),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    loader.assert_called_once_with('app', YAML('.yml'))
+
+    with pytest.raises(ValueError, match='format and extension'):
+        load_name('app', extension='jsn', format=JSON)
 
 
 def test_dumps():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -229,12 +229,14 @@ def test_load_name_order(tilde_home_user):
             call(Path('/Library/Preferences/bar.yaml'), format=YAML, default=NotConfigured),
             call(Path('/home/user/.config/foo.yaml'), format=YAML, default=NotConfigured),
             call(Path('/home/user/.config/bar.yaml'), format=YAML, default=NotConfigured),
-            call(Path('/home/user/Library/Preferences/foo.yaml'), format=YAML, default=NotConfigured),
-            call(Path('/home/user/Library/Preferences/bar.yaml'), format=YAML, default=NotConfigured),
+            # loadf is usually the one to expand ~ to /home/user here, but we've mocked it, so the value being passed
+            # will still contain the ~
+            call(Path('~/Library/Preferences/foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('~/Library/Preferences/bar.yaml'), format=YAML, default=NotConfigured),
             call(Path('C:/Users/user/AppData/Local/foo.yaml'), format=YAML, default=NotConfigured),
             call(Path('C:/Users/user/AppData/Local/bar.yaml'), format=YAML, default=NotConfigured),
-            call(Path('/home/user/.foo.yaml'), format=YAML, default=NotConfigured),
-            call(Path('/home/user/.bar.yaml'), format=YAML, default=NotConfigured),
+            call(Path('~/.foo.yaml'), format=YAML, default=NotConfigured),
+            call(Path('~/.bar.yaml'), format=YAML, default=NotConfigured),
             call(Path('./foo.yaml'), format=YAML, default=NotConfigured),
             call(Path('./bar.yaml'), format=YAML, default=NotConfigured),
         ],

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -435,7 +435,7 @@ def test_dumpf():
     with patch.object(Path, 'open', mock_open()) as mocked_open:
         dumpf(Configuration({'ns.key1': True, 'ns.key2': None}), '/path/to/dumped.yaml')
 
-    mocked_open.assert_called_once_with('wb')
+    mocked_open.assert_called_once_with('wt', encoding='utf-8')
     write = mocked_open().write
     for s in ('ns', 'key1', 'key2', 'null'):
         write.assert_any_call(str_containing(s))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -333,6 +333,10 @@ def test_load_name_envvars():
     assert subject.types.num == 42
     assert subject.types.maybe is True
 
+    with patch('confidence.io.environ', {'KEY_FOO': 'foo', 'BAR_CONFIG_FILE': '/tmp/bar.conf'}):
+        # neither environment variable should be hit here
+        assert not load_name('foo', 'bar', load_order=(read_envvars,))
+
 
 def test_load_name_envvar_file(test_files):
     env = {

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -410,7 +410,7 @@ def test_load_name_deprecated_extension():
         category=DeprecationWarning,
         stacklevel=2,
     )
-    loader.assert_called_once_with('app', YAML('.yml'))
+    loader.assert_called_once_with('app', YAML(suffix='.yml'))
 
     with pytest.raises(ValueError, match='format and extension'):
         load_name('app', extension='jsn', format=JSON)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -200,6 +200,8 @@ def test_load_name_multiple(test_files):
 
 
 def test_load_name_order(tilde_home_user):
+    # override actual environment variables for testing purposes
+    # (HOME is used for some XDG-specified locations, LOCALAPPDATA is used for windows-specific locations)
     env = {
         'HOME': '/home/user',
         'LOCALAPPDATA': 'C:/Users/user/AppData/Local',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import date
 
 import pytest
@@ -148,9 +147,5 @@ def test_split_key_types():
 
 
 def test_merge_deprecation():
-    with warnings.catch_warnings(record=True) as warned:
+    with pytest.warns(DeprecationWarning, match='renamed'):
         assert merge({}, {'a': 5}) == {'a': 5}
-
-    assert len(warned) == 1
-    assert issubclass(warned[0].category, DeprecationWarning)
-    assert 'renamed' in str(warned[0].message)


### PR DESCRIPTION
Maybe most important: nothing changes for anyone just calling `confidence.loadf()` with a bunch of files or even `load_name()`.

*Reviewers: there's more diff here than I would have liked, note that the most important bits are in `confidence/formats.py` (the actual `Format` spec and parsing calls) and and `confidence/io.py` (changing of parameters and delegation of things to the provided format).*

---

Move all of the `yaml.safe_load` calls into a `YAML` format object, and put a `JSON` format object next to it for good measure. These `Format` type objects can be used to control 

- the file format being read (so currently JSON or YAML);
- the file suffix used in file name / path templates (previously extension, though the suffix includes the dot [as it does with `Path.suffix`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffix));
- the text encoding for both reading and writing files.

The `JSON` implementation defaults to `.json` and `utf-8`, the `YAML` format defaults to `.yaml` and `utf-8`. With this in place, users can

- control the files being read in basically the same way (there's a deprecation warning when the 'extension' argument is used, but it will still work);
- add additional formats if they so desire.

The latter will not be part of this PR (it's grown big enough as it is), but at least an implementation of the TOML format that's gotten big in Python land is planned. This separation of path enumeration and the format being read from those locations should make adding something like that easy, while keeping the user-facing code nigh identical. 