### PR TITLE
Mimic behaviour of dict get, avoid KeyError by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+development (main)
+------------------
+
+- Let `Configuration.get()` mimic the behaviour of `dict.get()`, returning `None` by default for missing keys.
+
 0.16 (2025-04-18)
 -----------------
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 
 import pytest
 
-from confidence import Configuration, ConfigurationError, loadf
+from confidence import Configuration, loadf
 from confidence.models import NoDefault
 
 
@@ -10,13 +10,10 @@ def test_empty():
     def run_test(subject):
         assert subject.get('path.without.value', default=None) is None
         assert subject.get('another.path.without.value', default=4) == 4
-        with pytest.raises(ConfigurationError) as e:
-            subject.get('some_long.path')
-        assert 'some_long' in str(e.value)
-        with pytest.raises(KeyError) as e:
+        assert subject.get('some_long.path') is None
+        with pytest.raises(KeyError, match='some_long'):
             subject['some_long']
-        assert 'some_long' in str(e.value)
-        with pytest.raises(KeyError) as e:
+        with pytest.raises(KeyError, match='some_long') as e:
             subject['some_long.path']
         assert 'path' not in str(e.value)
 

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -2,7 +2,6 @@ import pickle
 
 import pytest
 
-from confidence.exceptions import NotConfiguredError
 from confidence.models import Configuration, Missing, NotConfigured
 
 
@@ -33,8 +32,7 @@ def test_missing_error():
     reencoded = pickle.loads(pickle.dumps(subject))
 
     assert subject.testing == reencoded.testing == 123
-    with pytest.raises(NotConfiguredError):
-        assert not reencoded.get('not_there')
+    assert reencoded.get('not_there') is None  # should *not* trigger the missing setting
     with pytest.raises(AttributeError):
         assert not reencoded.not_there
 


### PR DESCRIPTION
Only raise the an error when `default=NoDefault`, as specified by `config['path.key']` and required by the internal reference resolver.

Closes #124 