### PR TITLE
Catch just FileNotFoundError

### DIFF
--- a/confidence/io.py
+++ b/confidence/io.py
@@ -293,8 +293,7 @@ def loadf(
     def readf(fpath: Path) -> Mapping[str, Any]:
         try:
             return format.loadf(fpath)
-        except OSError:
-            # file does not exist or inaccessible
+        except FileNotFoundError:
             if default is NoDefault:
                 # no explicit default provided, continue original error
                 raise


### PR DESCRIPTION
Would letting `PermissionError` (and any other `OSError`s) slip create issues elsewhere 🤔 

See #123 