### PR TITLE
Align key ordering between formats, retain iteration order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ development (main)
 
 - Enable loaders in `load_name`'s load order to be `pathlib.Path` objects, which get formatted like string template loaders (e.g. `'/path/to/{name}{suffix}'` is equivalent to `Path('/path/to/{name}{suffix}')`).
 - Use pattern matching over type checks, speeding up a lot of things.
+- Align key sorting behaviour between bundled formats when dumping, all of which now keep iteration order of the value being dumped.
 
 0.17.2 (2025-11-25)
 -------------------

--- a/confidence/formats.py
+++ b/confidence/formats.py
@@ -68,7 +68,7 @@ class _JSONFormat(Format):
         return json.loads(string)
 
     def dumps(self, value: typing.Any) -> str:
-        return json.dumps(unwrap(value))
+        return json.dumps(unwrap(value), sort_keys=False)
 
 
 @dataclass(frozen=True)
@@ -87,7 +87,7 @@ class _TOMLFormat(Format):
         value = unwrap(value)
         try:
             # attempt to dump the value as TOML document
-            return tomlkit.dumps(value)
+            return tomlkit.dumps(value, sort_keys=False)
         except TypeError:
             # fall back to stringifying it as a single value / item
             return tomlkit.item(value).as_string()
@@ -103,7 +103,7 @@ class _YAMLFormat(Format):
     def dumps(self, value: typing.Any) -> str:
         # use block style output for nested collections (flow style dumps nested dicts inline)
         # omit explicit document end (...) included with simple values
-        return yaml.safe_dump(unwrap(value), default_flow_style=False).removesuffix('\n...\n')
+        return yaml.safe_dump(unwrap(value), default_flow_style=False, sort_keys=False).removesuffix('\n...\n')
 
 
 # expose *instances* of the formats defined here for users to interact with, editable by calling them (see __call__)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,4 +1,5 @@
 from dataclasses import FrozenInstanceError
+from itertools import pairwise
 
 import pytest
 
@@ -35,6 +36,23 @@ def test_multiple_values_roundtrip(format, value, tmp_path):
 
     format.dumpf(value, fname)
     assert format.loadf(fname) == unwrap(value)
+
+
+@pytest.mark.parametrize('format', (JSON, TOML, YAML))
+def test_dumps_retain_key_order(format):
+    # NB: keys deliberately not in ascending or descending order
+    value = {
+        'ccccc': 12,
+        'aaaaa': 34,
+        'bbbbb': 56,
+    }
+
+    assert list(value.keys()) == ['ccccc', 'aaaaa', 'bbbbb']
+    serialized = format.dumps(value)
+    # collect reversed locations of the same keys in the serialized result
+    indices = [serialized.index(key) for key in ['ccccc', 'aaaaa', 'bbbbb']]
+    for low, high in pairwise(indices):
+        assert low < high
 
 
 def test_edit_format():


### PR DESCRIPTION
Fixes #140 